### PR TITLE
Add wikimedia platformification

### DIFF
--- a/drupal8/Makefile
+++ b/drupal8/Makefile
@@ -2,10 +2,10 @@
 
 all: update platformify branch push
 
-reset:
+clean:
 	rm -rf template
 
-init: reset
+init: clean
 	git clone git@github.com:platformsh/template-drupal8.git template
 	cd template && git remote add upstream https://github.com/drupal-composer/drupal-project.git
 

--- a/wikimedia/.gitignore
+++ b/wikimedia/.gitignore
@@ -1,0 +1,1 @@
+template/

--- a/wikimedia/Makefile
+++ b/wikimedia/Makefile
@@ -1,0 +1,39 @@
+all: update platformify branch push
+
+clean:
+	rm -rf template
+
+init: clean
+	# getting a shallow clone of a specific version
+	git clone -b '1.29.2' --single-branch --depth 1 git@github.com:wikimedia/mediawiki.git template/web
+	
+update:
+	cd template && git fetch --all --depth=1
+
+platformify:
+	#Removing all git artificats
+	cd template && ( find . -type d -name ".git" && find . -name ".gitignore" && find . -name ".gitmodules" ) | xargs rm -rf
+	#Create new git Repo and add enerything
+	cd template && git init
+	cd template && git add . && git commit -m'Import from github upstream'
+	#Remove the stuff that shoulndn't be in production
+	rm -rf template/web/cache
+	rm -rf template/web/images
+	rm -rf template/web/mw-config
+	#Copy over Platform.sh configuration
+	rsync -aP files/ template/
+	#	patch  template/web/.gitignore <patches/0001-Apply-default-platform.sh-configuration.patch
+	#The follofinw patch allows us to run the installation script although LocalSettings.php already exists
+	patch template/web/includes/installer/CliInstaller.php < patches/0001-ignore-localsettings.patch
+	cd template/web && composer update --no-dev
+	#Unhelpfully composer based Skins end up in web/skins rather than vendor/ removing those
+	cd template/web && (find . -type d -name ".git") | xargs rm -rf
+	cd template && git add . && git commit -am'Apply default platform.sh configuration'
+
+branch:
+	cd template && git checkout -b update
+	cd template && git add -A && git commit -m "Update to latest upstream"
+
+push:
+	cd template && git checkout update && git push -u origin update
+	cd template && hub pull-request -m "Update to latest upstream" -b master -h update

--- a/wikimedia/files/.gitignore
+++ b/wikimedia/files/.gitignore
@@ -1,0 +1,2 @@
+#Platform.sh
+.platform/local/

--- a/wikimedia/files/.platform.app.yaml
+++ b/wikimedia/files/.platform.app.yaml
@@ -1,0 +1,61 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: php:7.1
+build:
+    flavor: none
+hooks:
+    build: |
+      cd web
+      composer install --no-dev
+    deploy: |
+      if [ ! -f /app/install/install.log ]; then
+        php web/maintenance/install.php  --dbname=main --dbserver="database.internal" --installdbuser=user --installdbpass= --dbuser=user --dbpass= --scriptpath=/ --lang=en --pass=changeme "Platform.sh wikimedia example" "admin" >/app/install/install.log
+        echo "Please change the admin password"
+      fi
+      cd web
+      php maintenance/update.php --quick
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: 'mysqldb:mysql'
+    cache: "memcached:memcached"
+
+# The size of the persistent disk of the application (in MB).
+disk: 1024
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    # Storage for Craft-writeable files.
+    "/images": "shared:files/storage"
+    "/cache": "shared:files/cache"
+    "/install": "shared:files/install"
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/wiki":
+            # The public directory of the app, relative to its root.
+            root: "web"
+            # The front-controller script to send non-static requests to.
+            passthru: "/index.php"
+            index:
+              - index.php
+            allow: true
+        # Allow uploaded files to be served, but do not run scripts.
+        # Missing files get mapped to the front controller above.
+        '/web/cache':
+            root: 'web/cache'
+            scripts: false
+            allow: true
+        '/web/images':
+            root: 'web/images'
+            scripts: false
+            allow: true

--- a/wikimedia/files/.platform/routes.yaml
+++ b/wikimedia/files/.platform/routes.yaml
@@ -1,0 +1,14 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+      enabled: false
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/wikimedia/files/.platform/services.yaml
+++ b/wikimedia/files/.platform/services.yaml
@@ -1,0 +1,5 @@
+mysqldb:
+    type: mysql:10.2
+    disk: 2048
+memcached:
+    type: memcached:1.4

--- a/wikimedia/files/README.md
+++ b/wikimedia/files/README.md
@@ -1,0 +1,22 @@
+# WikiMedia project template for Platform.sh
+
+This project provides a starter kit for WikiMedia instances hosted on [Platform.sh](http://platform.sh). 
+
+## Starting a new project
+
+To start a new WikiMedia instance on Platform.sh, you have 2 options:
+
+1. Create a new project through the Platform.sh user interface and select "import your existing code"
+2. Add Platform.sh as a git remote and push
+
+Tada. You have a running wikimedia installation.
+
+## Using as a reference
+
+You can also use this repository as a reference for your own wikimedia based projects, and borrow whatever code is needed.  The most important parts are the [`.platform.app.yaml`](/.platform.app.yaml) file and the [`.platform`](/.platform) directory as well as what we put in composer.local.json and LocalSettings.php
+
+Also see:
+
+* [`settings.php`](/web/sites/default/settings.php) - The customized `settings.php` file works for both Platform.sh and local development, setting only those values that are needed in both.  You can add additional values as documented in `default.settings.php` as desired.
+* [`settings.platformsh.php`](/web/sites/default/settings.platformsh.php) - This file contains Platform.sh-specific code to map environment variables into Drupal configuration.  You can add to it as needed.  See [the documentation](https://docs.platform.sh/frameworks/drupal8.html) for more examples of common snippets to include here.
+* [`scripts/platformsh`](/scripts/platformsh) - This directory contains our update script to keep this repository in sync with the Drupal Composer project.  It may be safely ignored or removed.

--- a/wikimedia/files/web/.gitignore
+++ b/wikimedia/files/web/.gitignore
@@ -1,0 +1,64 @@
+# Repository management
+.svn
+
+# git-deploy status file:
+/.deploy
+
+# Editors
+*.kate-swp
+*~
+\#*#
+.#*
+.*.swp
+.project
+cscope.files
+cscope.out
+*.orig
+## NetBeans
+nbproject*
+project.index
+## Sublime
+sublime-*
+sftp-config.json
+
+# MediaWiki install & usage
+/images
+/cache
+/docs/js
+/maintenance/.mweval_history
+/maintenance/.mwsql_history
+/maintenance/dev/data
+/AdminSettings.php
+/StartProfiler.php
+
+# Building & testing
+node_modules/
+/tests/phpunit/phpunit.phar
+
+# Composer
+/vendor
+# Composer install of skins goes here not to vendor.
+/web/skins/Vector*
+
+# MediaWiki UI documentation
+/docs/kss/static
+
+# Operating systems
+## Mac OS X
+.DS_Store
+## Windows
+Thumbs.db
+
+# Misc
+.buildpath
+.classpath
+.idea
+.metadata*
+.settings
+/favicon.ico
+/static*
+/tags
+/.htaccess
+/.htpasswd
+/tests/phan/issues
+*.rej

--- a/wikimedia/files/web/LocalSettings.php
+++ b/wikimedia/files/web/LocalSettings.php
@@ -1,0 +1,33 @@
+<?php
+/**
+* MediaWiki Sample Platform.sh configuration
+* with Memcache support
+*/
+
+if (!empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
+  $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
+  if (!empty($relationships['cache'])) {
+    $wgMemCachedServers = [ $relationships['cache'][0]['host'].':' . $relationships['cache'][0]['port']];
+  }
+  if (!empty($relationships['database'])) {
+    $wgDBserver = $relationships['database'][0]['host'];
+    $wgDBport = $relationships['database'][0]['port'];
+    $wgDBname = $relationships['database'][0]['path'];
+    $wgDBuser = $relationships['database'][0]['username'];
+    $wgDBpassword = $relationships['database'][0]['password'];
+  }
+  $wgSMTP = ['host'=>$_ENV['PLATFORM_SMTP_HOST'], 'IDHost'   => '', 'port' => '25', 'username' => '', 'password' => ''];
+}
+
+$wgCacheDirectory = "/app/cache";
+
+$wgScriptPath ="/wiki";
+$wgScript = "{$wgScriptPath}/";
+$wgArticlePath = "/wiki/$1";
+$wgUsePathInfo = true;
+
+$wgMainCacheType = CACHE_MEMCACHED;
+
+wfLoadSkin( 'Vector' );
+$wgShowExceptionDetails = true;
+$wgShowDBErrorBacktrace = true;

--- a/wikimedia/files/web/composer.local.json
+++ b/wikimedia/files/web/composer.local.json
@@ -1,0 +1,22 @@
+{ 
+  "minimum-stability": "dev",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/wikimedia/mediawiki-skins-Material"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/wikimedia/mediawiki-skins-Vector"
+    },
+    {
+      "type": "pear",
+      "url": "https://pear.php.net"
+    }
+  ],
+  "require": {
+    "mediawiki/vector-skin": "dev-master",
+    "pear/mail": "*",
+    "pear/Net_SMTP": "*"
+  }
+}

--- a/wikimedia/patches/0001-Apply-default-platform.sh-configuration.patch
+++ b/wikimedia/patches/0001-Apply-default-platform.sh-configuration.patch
@@ -1,0 +1,32 @@
+From 3fde3e28531dcd23efe036d57c790d37ec80cc8a Mon Sep 17 00:00:00 2001
+From: Ori Pekelman <ori@platform.sh>
+Date: Fri, 24 Nov 2017 14:41:00 +0100
+Subject: [PATCH] Apply default platform.sh configuration
+
+--- .gitignore
++++ (clipboard)
+@@ -22,7 +22,6 @@
+ sftp-config.json
+ 
+ # MediaWiki install & usage
+-/cache
+ /images
+ /cache
+ /docs/js
+@@ -47,7 +46,10 @@
+ /tests/phpunit/phpunit.phar
+ 
+ # Composer
+-/vendor
++/composer.lock
++/composer.json
++/composer.local.json
++
+ # MediaWiki UI documentation
+ /docs/kss/static
+ 
+@@ -70,4 +72,3 @@
+ /.htpasswd
+ /tests/phan/issues
+ *.rej
+-

--- a/wikimedia/patches/0001-ignore-localsettings.patch
+++ b/wikimedia/patches/0001-ignore-localsettings.patch
@@ -1,0 +1,25 @@
+From 0a997ea2ddc7ec6d0cd8eca1680d50330a15c3cf Mon Sep 17 00:00:00 2001
+From: Ori Pekelman <ori@platform.sh>
+Date: Fri, 24 Nov 2017 18:39:40 +0100
+Subject: [PATCH] ignore localsettings
+
+---
+ web/includes/installer/CliInstaller.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/web/includes/installer/CliInstaller.php b/web/includes/installer/CliInstaller.php
+index 661c3ec..2038cff 100644
+--- a/web/includes/installer/CliInstaller.php
++++ b/web/includes/installer/CliInstaller.php
+@@ -124,7 +124,7 @@ class CliInstaller extends Installer {
+ 	 */
+ 	public function execute() {
+ 		$vars = Installer::getExistingLocalSettings();
+-		if ( $vars ) {
++		if ( $vars  && false) {
+ 			$this->showStatusMessage(
+ 				Status::newFatal( "config-localsettings-cli-upgrade" )
+ 			);
+-- 
+2.15.0
+


### PR DESCRIPTION
Played a bit with your approach. I think we will want a structure where: 

1.  We copy over stuff (making it as DRY as possible) so maybe we name configs like "default-mysql-elasticsearch-redis" for services.yaml or something
2. we copy over stuff while templating (so service names can come from parsing these DRY base configs) using for example https://github.com/markround/tiller
3.  We patch stuff

For me the main question is whether we keep the original git repo reference .. (basically how would the "update" work). In my example I am just exporting the git and killing it. TBD