### PR TITLE
Symfony 3 update

### DIFF
--- a/symfony3/files/.platform.app.yaml
+++ b/symfony3/files/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: app
 
 # The type of the application to build.
-type: php:7.1
+type: php:7.2
 build:
     flavor: composer
 

--- a/symfony3/files/app/config/parameters_platformsh.php
+++ b/symfony3/files/app/config/parameters_platformsh.php
@@ -6,9 +6,9 @@
  */
 
 // Configure the database.
-if (isset($_ENV['PLATFORM_RELATIONSHIPS'])) {
+if (getenv('PLATFORM_RELATIONSHIPS')) {
     $dbRelationshipName = 'database';
-    $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), true);
+    $relationships = json_decode(base64_decode(getenv('PLATFORM_RELATIONSHIPS')), true);
     foreach ($relationships[$dbRelationshipName] as $endpoint) {
         if (!empty($endpoint['query']['is_master'])) {
             $container->setParameter('database_driver', 'pdo_'.$endpoint['scheme']);
@@ -24,6 +24,6 @@ if (isset($_ENV['PLATFORM_RELATIONSHIPS'])) {
 }
 
 // Set a default unique secret, based on a project-specific entropy value.
-if (isset($_ENV['PLATFORM_PROJECT_ENTROPY'])) {
-    $container->setParameter('kernel.secret', $_ENV['PLATFORM_PROJECT_ENTROPY']);
+if (getenv('PLATFORM_PROJECT_ENTROPY')) {
+    $container->setParameter('kernel.secret', getenv('PLATFORM_PROJECT_ENTROPY'));
 }

--- a/symfony3/parameters.patch
+++ b/symfony3/parameters.patch
@@ -5,10 +5,10 @@ index ed744a3..b231be4 100644
 @@ -1,5 +1,6 @@
  imports:
      - { resource: parameters.yml }
-+    - { resource: parameters_patformsh.php }
++    - { resource: parameters_platformsh.php }
      - { resource: security.yml }
      - { resource: services.yml }
- 
+
 @@ -46,6 +47,7 @@ doctrine:
          user: '%database_user%'
          password: '%database_password%'


### PR DESCRIPTION
* Fix bug in the patch file.
* Switch to PHP 7.2.
* Resync with the -example repo.

This is now ready to be made the canonical Symfony 3 starter kit.