### PR TITLE
Use PHP 7.2 for Symfony 4.

### DIFF
--- a/symfony4/files/.platform.app.yaml
+++ b/symfony4/files/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: app
 
 # The type of the application to build.
-type: php:7.1
+type: php:7.2
 build:
     flavor: composer
 


### PR DESCRIPTION
Because reasons.