### PR TITLE
Laravel - updating readme to include changes we made

### DIFF
--- a/laravel/files/README.md
+++ b/laravel/files/README.md
@@ -7,7 +7,7 @@ This project provides a starter kit for Laravel projects hosted on Platform.sh. 
 To start a new project based on this template, follow these 3 simple steps:
 
 1. Clone this repository locally.  You may optionally remove the `origin` remote or remove the `.git` directory and re-init the project if you want a clean history.
- 
+
 2. Create a new project through the Platform.sh user interface and select "Import an existing project" when prompted.
 
 3. Run the provided Git commands to add a Platform.sh remote and push the code to the Platform.sh repository.
@@ -21,5 +21,30 @@ You can use this repository as a reference for your own projects, and borrow wha
 You also will need the [platformsh/laravel-bridge](https://github.com/platformsh/laravel-bridge) composer library.  It can be installed like any other composer library:
 
 `composer require platformsh/laravel-bridge`
+
+## Redis
+
+Please note that this project is using the PhpRedis PHP extension via PECL. As such, the redis client in `config/database.php` file has been manually patched to `phpredis` in this repo as shown below:
+
+```
+'redis' => [
+
+    'client' => 'phpredis',
+
+    // Rest of Redis configuration...
+],
+```
+
+### Cache and Session Driver
+
+Redis has also been enabled as the default Laravel Cache and Session driver with the below relationships defined in the `.platform.app.yaml` file.
+
+```
+relationships:
+    rediscache: "redis:redis"
+    redissession: "redis:redis"
+```
+
+With `rediscache` and `redissession` defined above, the [platformsh/laravel-bridge](https://github.com/platformsh/laravel-bridge) composer library will automatically perform the necessary mappings to set redis as the default cache and session driver.
 
 That's all you need to make a Laravel application run on Platform.sh!


### PR DESCRIPTION
1) Pointing out the phpredis patch that we made

2) Also making it more clear that redis is being used by default as Laravel's cache and session driver (vanilla Laravel uses a different default for these).