### PR TITLE
Automatically dereive the latest tag for a remote project to merge from

### DIFF
--- a/project/laravel.py
+++ b/project/laravel.py
@@ -2,7 +2,7 @@ from .remote import RemoteProject
 
 
 class Laravel(RemoteProject):
-    upstream_tag = 'v5.8.3'
+    major_version = 'v5'
     remote = 'https://github.com/laravel/laravel.git'
 
     @property

--- a/project/magento.py
+++ b/project/magento.py
@@ -2,5 +2,5 @@ from .remote import RemoteProject
 
 
 class Magento2ce(RemoteProject):
-    upstream_branch = '2.2'
+    major_version = '2.2'
     remote = 'https://github.com/magento/magento2.git'

--- a/project/remote.py
+++ b/project/remote.py
@@ -38,17 +38,13 @@ class RemoteProject(BaseProject):
                 subprocess.check_output('cd {0} && git merge --allow-unrelated-histories -X theirs --squash {1}'.format(
                 self.builddir, latest_tag), shell=True)
             actions.append(merge_from_upstream_tag)
-        elif hasattr(self, 'upstream_tag'):
-            actions.append(
-                'cd {0} && git merge --allow-unrelated-histories -X theirs --squash {1}'.format(
-                    self.builddir, self.upstream_tag))
         elif hasattr(self, 'upstream_branch'):
             actions.append(
                 'cd {0} && git merge --allow-unrelated-histories -X theirs --squash project/{1}'.format(
                     self.builddir, self.upstream_branch))
         else:
             raise AttributeError(
-                'Each RemoteProject subclass must contain either a upstream_tag or upstream_branch class attribute.')
+                'Each RemoteProject subclass must contain either a major_version or upstream_branch class attribute.')
 
         # Do this last so it picks up all changes from above.
         actions.extend(self.packageUpdateActions())

--- a/project/remote.py
+++ b/project/remote.py
@@ -1,5 +1,5 @@
 from . import BaseProject
-
+import subprocess
 
 class RemoteProject(BaseProject):
     '''
@@ -10,12 +10,9 @@ class RemoteProject(BaseProject):
 
     Projects extending this class MUST define the following class attributes:
     - `remote`, which is a Git URL to the upstream source.
-    - either `upstream_tag` or `upstream_branch`, which specifies the tag or branch
-        in the `remote` repository from which to pull. (If both are defined, `upstream_tag`
-        take precedence.)
-
-    Note that if using a tag, that means the project class will need to be updated
-    every time there's a new upstream release.  C'est la vie.
+    - `major_version`, which is the prefix of legal tags that can be merged from.
+        So "5" will always to the most recent 5.y.z tag, "v3.4" will update to the latest
+        "v.3.4.z" tag, etc.
     '''
 
     @property
@@ -33,7 +30,13 @@ class RemoteProject(BaseProject):
             'cd {0} && git fetch --all --tags'.format(self.builddir),
         ]
 
-        if hasattr(self, 'upstream_tag'):
+        if hasattr(self, 'major_version'):
+            def merge_from_upstream_tag():
+                latest_tag = self.latest_tag()
+                subprocess.check_output('cd {0} && git merge --allow-unrelated-histories -X theirs --squash {1}'.format(
+                self.builddir, latest_tag), shell=True)
+            actions.append(merge_from_upstream_tag)
+        elif hasattr(self, 'upstream_tag'):
             actions.append(
                 'cd {0} && git merge --allow-unrelated-histories -X theirs --squash {1}'.format(
                     self.builddir, self.upstream_tag))
@@ -49,3 +52,18 @@ class RemoteProject(BaseProject):
         actions.extend(self.packageUpdateActions())
 
         return actions
+
+    def latest_tag(self):
+        """
+        :return: string The version number of the most up to date tag matching the current major version.
+        """
+        tags = subprocess.check_output('cd {0} && git tag'.format(self.builddir), shell=True).decode('utf-8').splitlines()
+        tags = [tag for tag in tags if tag.startswith(self.major_version)]
+        tags.sort(key=lambda s: [u for u in s.split('.')], reverse=True)
+
+        tag = next(iter(tags), None)
+
+        if tag == None:
+            raise Exception('No upstream tag found to merge from')
+
+        return tag

--- a/project/remote.py
+++ b/project/remote.py
@@ -13,6 +13,8 @@ class RemoteProject(BaseProject):
     - `major_version`, which is the prefix of legal tags that can be merged from.
         So "5" will always to the most recent 5.y.z tag, "v3.4" will update to the latest
         "v.3.4.z" tag, etc.
+    - OR `upstream_branch`, which specifies the tag or branch in the `remote` repository
+        from which to pull. (If both are defined, `major_version` take precedence.)
     '''
 
     @property

--- a/project/symfony.py
+++ b/project/symfony.py
@@ -2,7 +2,7 @@ from .remote import RemoteProject
 
 
 class Symfony3(RemoteProject):
-    upstream_branch = '3.4'
+    major_version = '3.4'
     remote = 'https://github.com/symfony/symfony-standard.git'
 
     @property
@@ -18,7 +18,7 @@ class Symfony3(RemoteProject):
 
 
 class Symfony4(RemoteProject):
-    upstream_branch = '4.2'
+    major_version = '4'
     remote = 'https://github.com/symfony/skeleton.git'
 
     @property

--- a/project/symfony.py
+++ b/project/symfony.py
@@ -2,7 +2,7 @@ from .remote import RemoteProject
 
 
 class Symfony3(RemoteProject):
-    major_version = '3.4'
+    major_version = 'v3.4'
     remote = 'https://github.com/symfony/symfony-standard.git'
 
     @property
@@ -18,7 +18,7 @@ class Symfony3(RemoteProject):
 
 
 class Symfony4(RemoteProject):
-    major_version = '4'
+    major_version = 'v4'
     remote = 'https://github.com/symfony/skeleton.git'
 
     @property

--- a/project/wordpress.py
+++ b/project/wordpress.py
@@ -5,7 +5,7 @@ from .remote import RemoteProject
 
 
 class Wordpress(RemoteProject):
-    upstream_tag = '5.0.3'
+    major_version = '5'
     remote = 'https://github.com/johnpbloch/wordpress.git'
 
     @property

--- a/templates/magento2ce/platformsh.patch
+++ b/templates/magento2ce/platformsh.patch
@@ -19,34 +19,14 @@ diff --git a/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php 
 index 00fa272e749620b2b737d2fbe67113411e18217d..fd89c02ddb911ac7ea057a46b189e2ba0ff676f9 100644
 --- a/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
 +++ b/setup/src/Magento/Setup/Console/Command/AdminUserCreateCommand.php
-@@ -170,20 +170,20 @@ class AdminUserCreateCommand extends AbstractSetupCommand
-     public function getOptionsList()
+@@ -177,6 +177,7 @@ class AdminUserCreateCommand extends AbstractSetupCommand
+      */
+     public function getOptionsList($mode = InputOption::VALUE_REQUIRED)
      {
++        $mode = InputOption::VALUE_OPTIONAL;
+         $requiredStr = ($mode === InputOption::VALUE_REQUIRED ? '(Required) ' : '');
+
          return [
--            new InputOption(AdminAccount::KEY_USER, null, InputOption::VALUE_REQUIRED, '(Required) Admin user'),
--            new InputOption(AdminAccount::KEY_PASSWORD, null, InputOption::VALUE_REQUIRED, '(Required) Admin password'),
--            new InputOption(AdminAccount::KEY_EMAIL, null, InputOption::VALUE_REQUIRED, '(Required) Admin email'),
-+            new InputOption(AdminAccount::KEY_USER, null, InputOption::VALUE_OPTIONAL, 'Admin user'),
-+            new InputOption(AdminAccount::KEY_PASSWORD, null, InputOption::VALUE_OPTIONAL, 'Admin password'),
-+            new InputOption(AdminAccount::KEY_EMAIL, null, InputOption::VALUE_OPTIONAL, 'Admin email'),
-             new InputOption(
-                 AdminAccount::KEY_FIRST_NAME,
-                 null,
--                InputOption::VALUE_REQUIRED,
--                '(Required) Admin first name'
-+                InputOption::VALUE_OPTIONAL,
-+                'Admin first name'
-             ),
-             new InputOption(
-                 AdminAccount::KEY_LAST_NAME,
-                 null,
--                InputOption::VALUE_REQUIRED,
--                '(Required) Admin last name'
-+                InputOption::VALUE_OPTIONAL,
-+                'Admin last name'
-             ),
-         ];
-     }
 @@ -196,6 +196,7 @@ class AdminUserCreateCommand extends AbstractSetupCommand
       */
      public function validate(InputInterface $input)
@@ -92,17 +72,6 @@ diff --git a/setup/src/Magento/Setup/Model/Installer.php b/setup/src/Magento/Set
 index ba85081f9e169d06664f57fc55216ec440b5deb5..f7eeddf0f5790841ee4deed1011c1ffc2417eba7 100644
 --- a/setup/src/Magento/Setup/Model/Installer.php
 +++ b/setup/src/Magento/Setup/Model/Installer.php
-@@ -316,7 +316,9 @@ class Installer
-                 [$request[InstallCommand::INPUT_KEY_SALES_ORDER_INCREMENT_PREFIX]],
-             ];
-         }
--        $script[] = ['Installing admin user...', 'installAdminUser', [$request]];
-+        if (isset($request['admin-email'])) {
-+            $script[] = ['Installing admin user...', 'installAdminUser', [$request]];
-+        }
-         $script[] = ['Caches clearing:', 'cleanCaches', []];
-         $script[] = ['Disabling Maintenance Mode:', 'setMaintenanceMode', [0]];
-         $script[] = ['Post installation file permissions check...', 'checkApplicationFilePermissions', []];
 @@ -450,6 +452,7 @@ class Installer
       */
      public function checkInstallationFilePermissions()


### PR DESCRIPTION
I've tested this against Laravel, but not the other projects yet.  But it does remove an annoying bit of hard coding in a nice way.

Also, we have to keep upstream_branch as the Drupal Composer upstream project... has no tags.  It's just an 8.x branch that wraps whatever the latest tagged version of Drupal is.  So... *sigh*

Drupal 7 is also an oddball since that needs updates to the makefile, not just to the definition class.  That hasn't been addressed yet here.
