### PR TITLE
Update Drupal7 and Drupal8 templates for security update.

### DIFF
--- a/templates/drupal7/files/.platform.template.yaml
+++ b/templates/drupal7/files/.platform.template.yaml
@@ -21,7 +21,7 @@ info:
   # Unique machine name, prefaced by a vendor or organization identifier
   id: platformsh/drupal7
   # The human-readable name of the template.
-  name: Drupal 7 (Drush make)
+  name: Drupal 7
   # Human-readable descriptive text for the template. Supports limited HTML.
   description: Drupal is a highly-customizable free software PHP CMS that allows you to easily organize, manage and publish your content.
   # A list of tags associated with the template.

--- a/templates/drupal7/files/project.make
+++ b/templates/drupal7/files/project.make
@@ -3,7 +3,7 @@ core = 7.x
 
 ; Drupal core.
 projects[drupal][type] = core
-projects[drupal][version] = 7.66
+projects[drupal][version] = 7.67
 projects[drupal][patch][] = "https://drupal.org/files/issues/install-redirect-on-empty-database-728702-36.patch"
 
 ; Drush make allows a default sub directory for all contributed projects.


### PR DESCRIPTION
Drupal security updates: https://www.drupal.org/sa-core-2019-007

See also:
https://github.com/platformsh/template-drupal8/pull/43
https://github.com/platformsh/template-drupal7/pull/14