### PR TITLE
Switch to Magento 2.3

### DIFF
--- a/project/magento.py
+++ b/project/magento.py
@@ -2,5 +2,5 @@ from .remote import RemoteProject
 
 
 class Magento2ce(RemoteProject):
-    major_version = '2.2'
+    major_version = '2.3'
     remote = 'https://github.com/magento/magento2.git'

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -7,12 +7,11 @@
 name: magento
 
 # The runtime the application uses.
-type: php:7.1
+type: php:7.2
 
 # Specify additional PHP extensions that should be loaded.
 runtime:
     extensions:
-    - mcrypt
     - xsl
 
 # Configuration of the build of this application.


### PR DESCRIPTION
What's not shown here is that I had to do a manual update of Magento itself as it had Git file conflicts with... itself.  I don't fully understand why.  Also, Magento is huge.

The patch file has some line offsets but still applies.  I have not modified it but to avoid stray .orig files in the future we may want to reroll it at some point.

This also switches to PHP 7.2, which requires removing mcrpyt as that's been removed in 7.2.

This does build: https://github.com/platformsh/template-magento2ce/pull/8

However, to really make sure everything works I think we'll need to update the repo, then try to do a second update and make sure everything in this PR "takes" properly.  I'm not sure if a better way.