### PR TITLE
Make the minimum version of symfonyflex-bridge explicit

### DIFF
--- a/project/symfony.py
+++ b/project/symfony.py
@@ -26,6 +26,6 @@ class Symfony4(RemoteProject):
     @property
     def platformify(self):
         return super(Symfony4, self).platformify + [
-            'cd {0} && composer require platformsh/symfonyflex-bridge'.format(
+            'cd {0} && composer require platformsh/symfonyflex-bridge ^2.1'.format(
                 self.builddir)
         ]


### PR DESCRIPTION
The latest update to Symfony adds a minimum-stability of "dev".  I don't know why.  But for some reason that is causing the default chosen version of symfonyflex-bridge to become 1.0@dev instead of the latest, which is 2.1.  I don't know why that happens, either.  But explicitly specifying a minimum version here works around that adequately so it works for now.