### PR TITLE
fixing mounts issue in .platform.app.yaml for Laravel template

### DIFF
--- a/templates/laravel/files/.platform.app.yaml
+++ b/templates/laravel/files/.platform.app.yaml
@@ -38,7 +38,7 @@ mounts:
   "storage/framework/sessions": "shared:files/sessions"
   "storage/framework/cache": "shared:files/cache"
   "storage/logs": "shared:files/logs"
-  "bootstrap/cache": "shared:files/bootstrap_cache"
+  "bootstrap/cache": "shared:files/bootstrap/cache"
 
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
Looks like the mounts were incorrectly defined, which was causing the file cache to fail (template was still working because we were using redis for cache by default).

See related discussion from Slack here: https://platformsh.slack.com/archives/C0JHEUHQD/p1561998987313800?thread_ts=1561997839.311200&cid=C0JHEUHQD

See PR made to the Laravel Template as well: https://github.com/platformsh/template-laravel/pull/20