### PR TITLE
Make weird fix.

### DIFF
--- a/project/drupal.py
+++ b/project/drupal.py
@@ -59,5 +59,5 @@ class Govcms8(RemoteProject):
 
         return super(Govcms8, self).platformify + [
             (govcms8_add_installer_paths, []),
-            'cd {0} && composer require govcms/govcms --ignore-platform-reqs'.format(self.builddir)
+            'cd {0} composer require govcms/govcms --ignore-platform-reqs'.format(self.builddir)
         ]


### PR DESCRIPTION
https://github.com/platformsh/template-govcms8/pull/5

This fix was necessary in order to run the `doit full:govcms8` during the description update above. It should be a syntax error, but instead it works. Should be further investigated. 