### PR TITLE
Fix Akeneo initialize.repository key

### DIFF
--- a/templates/akeneo/.platform.template.yaml
+++ b/templates/akeneo/.platform.template.yaml
@@ -49,7 +49,7 @@ info:
 # this key also gets mapped to the appropriate location in project.settings so
 # that the current UI can have its own workflow overridden as well.
 initialize:
-  repository: git@github.com:platformsh/template-akeneo.git@master
+  repository: git://github.com/platformsh/template-akeneo.git@master
   config: null
   files: []
   profile: Akeneo


### PR DESCRIPTION
The initialize.repository key in templates _only_ supports Git-protocol or HTTPS-protocol URIs, not SSH.