### PR TITLE
Modernize YAML conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ And poof, you are ready to make a PR with the updates.
 
 Template projects are hooked up to Platform.sh projects, so each new PR gets built as a new, empty environment ready for testing.  In most cases simply visiting the built site and verifying that the installer can run (if available) or that the site gives the appropriate "there's nothing here yet" error is sufficient, but further testing can be done if needed.
 
+## Conventions
+
+Templates should all follow some standard conventions for consistency and easier documentability, even though technically the Platform.sh code doesn't care.  There may be case-by-case exceptions to these guidelines but the following should be followed unless there is a good reason otherwise.
+
+* In single-application examples, the application name is always `app`.
+* Service names should be named for the *use case* they are primarily for.  For example, the primary database for an application is a service named `db` (regardless if it's MySQL, MariaDB, PostgreSQL, or MongoDB).  The main cache service should be named `cache`.  The main search service is named `search`.  Etc.
+* Relationship names should be named for the service type and use case.  Thus, a Redis service named `cache` will have a relationship name of `rediscache`.  A Solr service named `search` will have a relationship named `solrsearch`.  Etc.
+* As an exception to the previous point, the relationship for the primary database is called simply `database` regardless of its type.  This is largely for historical reasons, and because 99% of the time no one cares about the type at that level.
+* Always use the most recent version of a language or service container that the application supports.
+* Always use the most up-to-date syntax and style for YAML files.  For instance, always use the newer nested `mount` syntax, not the old inline version.
+* If including both a www-prefixed domain and not in `routes.yaml`, the bare domain should redirect to the www domain, not vice versa.
 
 ## Contributing
 

--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -17,8 +17,8 @@ runtime:
 # to the application in the environment variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    elasticsearch: "elasticsearch:elasticsearch"
+    database: "db:mysql"
+    elasticsearch: "search:elasticsearch"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -31,17 +31,34 @@ web:
 disk: 3072
 
 # The mounts that will be performed when the package is deployed.
-# Filesystem is read only by default
 mounts:
-    "var/logs":                 "shared:files/app-logs"
-    "var/cache":                "shared:files/app-cache"
-    "var/uploads":              "shared:files/app-uploads"
-    "app/file_storage":         "shared:files/app-file_storage"
-    "app/archive":              "shared:files/app-archive"
-    "app/uploads/product":      "shared:files/app-uploads"
-    "installer":                "shared:files/installer"
-    "web/media":                "shared:files/media-cache"
-    "upgrades/schema":          "shared:files/upgrades-schema"
+    "var/logs":
+        source: local
+        source_path: "app-logs"
+    "var/cache":
+        source: local
+        source_path: "app-cache"
+    "var/uploads":
+        source: local
+        source_path: "app-uploads"
+    "app/file_storage":
+        source: local
+        source_path: "app-file_storage"
+    "app/archive":
+        source: local
+        source_path: "app-archive"
+    "app/uploads/product":
+        source: local
+        source_path: "app-uploads"
+    "installer":
+        source: local
+        source_path: "installer"
+    "web/media":
+        source: local
+        source_path: "media-cache"
+    "upgrades/schema":
+        source: local
+        source_path: "upgrades-schema"
 
 hooks:
     # We run the build hook before your application has been packaged.

--- a/templates/akeneo/files/.platform/services.yaml
+++ b/templates/akeneo/files/.platform/services.yaml
@@ -2,9 +2,9 @@
 #
 # Each service listed will be deployed to power your project.
 
-mysqldb:
+db:
     type: oracle-mysql:5.7
     disk: 1024
-elasticsearch:
+search:
     type: elasticsearch:6.5
     disk: 512

--- a/templates/beego/files/.platform.app.yaml
+++ b/templates/beego/files/.platform.app.yaml
@@ -16,7 +16,7 @@ hooks:
         go build -o bin/app
 
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/beego/files/.platform/services.yaml
+++ b/templates/beego/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 1024

--- a/templates/django1/files/.platform.app.yaml
+++ b/templates/django1/files/.platform.app.yaml
@@ -15,7 +15,7 @@ type: 'python:2.7'
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "postgresqldb:postgresql"
+    database: "db:postgresql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/django1/files/.platform/services.yaml
+++ b/templates/django1/files/.platform/services.yaml
@@ -5,6 +5,6 @@
 #
 # See https://docs.platform.sh/user_guide/reference/services-yaml.html
 
-postgresqldb:
+db:
     type: postgresql:10
     disk: 1024

--- a/templates/django2/files/.platform.app.yaml
+++ b/templates/django2/files/.platform.app.yaml
@@ -20,7 +20,7 @@ dependencies:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "postgresqldb:postgresql"
+    database: "db:postgresql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/django2/files/.platform/services.yaml
+++ b/templates/django2/files/.platform/services.yaml
@@ -5,6 +5,6 @@
 #
 # See https://docs.platform.sh/user_guide/reference/services-yaml.html
 
-postgresqldb:
+db:
     type: postgresql:10
     disk: 1024

--- a/templates/drupal7/files/.platform.app.yaml
+++ b/templates/drupal7/files/.platform.app.yaml
@@ -24,9 +24,7 @@ dependencies:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: 'mysqldb:mysql'
-#    solr: 'solrsearch:solr'
-#    redis: 'rediscache:redis'
+    database: 'db:mysql'
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/drupal7/files/.platform.app.yaml
+++ b/templates/drupal7/files/.platform.app.yaml
@@ -83,10 +83,18 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-    '/public/sites/default/files': 'shared:files/files'
-    '/tmp': 'shared:files/tmp'
-    '/private': 'shared:files/private'
-    '/drush-backups': 'shared:files/drush-backups'
+    '/public/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:

--- a/templates/drupal7/files/.platform/services.yaml
+++ b/templates/drupal7/files/.platform/services.yaml
@@ -3,13 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048
-
-#rediscache:
-#    type: redis:3.0
-#
-#solrsearch:
-#    type: solr:3.6
-#    disk: 1024

--- a/templates/drupal7_vanilla/files/.platform.app.yaml
+++ b/templates/drupal7_vanilla/files/.platform.app.yaml
@@ -24,9 +24,7 @@ dependencies:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: 'mysqldb:mysql'
-#    solr: 'solrsearch:solr'
-#    redis: 'rediscache:redis'
+    database: 'db:mysql'
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/drupal7_vanilla/files/.platform.app.yaml
+++ b/templates/drupal7_vanilla/files/.platform.app.yaml
@@ -83,10 +83,18 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-    '/public/sites/default/files': 'shared:files/files'
-    '/tmp': 'shared:files/tmp'
-    '/private': 'shared:files/private'
-    '/drush-backups': 'shared:files/drush-backups'
+    '/public/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:

--- a/templates/drupal7_vanilla/files/.platform/services.yaml
+++ b/templates/drupal7_vanilla/files/.platform/services.yaml
@@ -3,13 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048
-
-#rediscache:
-#    type: redis:3.0
-#
-#solrsearch:
-#    type: solr:3.6
-#    disk: 1024

--- a/templates/drupal8/files/.platform.app.yaml
+++ b/templates/drupal8/files/.platform.app.yaml
@@ -27,16 +27,26 @@ runtime:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
-    '/web/sites/default/files': 'shared:files/files'
-    '/tmp': 'shared:files/tmp'
-    '/private': 'shared:files/private'
-    '/.drush': 'shared:files/.drush'
-    '/drush-backups': 'shared:files/drush-backups'
-    '/.console': 'shared:files/console'
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    '/.console':
+        source: local
+        source_path: 'console'
 
 # Configuration of the build of this application.
 build:

--- a/templates/drupal8/files/.platform.app.yaml
+++ b/templates/drupal8/files/.platform.app.yaml
@@ -15,9 +15,9 @@ type: 'php:7.2'
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: 'mysqldb:mysql'
+    database: 'db:mysql'
 ## Uncomment this line to enable Redis caching for Drupal.
-#    redis: 'rediscache:redis'
+#    redis: 'cache:redis'
 
 # Add additional PHP extensions.
 runtime:

--- a/templates/drupal8/files/.platform/services.yaml
+++ b/templates/drupal8/files/.platform/services.yaml
@@ -3,9 +3,9 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048
 
-rediscache:
+cache:
     type: redis:5.0

--- a/templates/drupal8multi/files/.platform.app.yaml
+++ b/templates/drupal8multi/files/.platform.app.yaml
@@ -27,9 +27,7 @@ runtime:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
     '/web/files':
         source: local

--- a/templates/echo/files/.platform.app.yaml
+++ b/templates/echo/files/.platform.app.yaml
@@ -21,7 +21,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/echo/files/.platform/services.yaml
+++ b/templates/echo/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 1024

--- a/templates/express/files/.platform.app.yaml
+++ b/templates/express/files/.platform.app.yaml
@@ -15,7 +15,7 @@ type: nodejs:10
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-  database: "mydatabase:mysql"
+  database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/express/files/.platform/services.yaml
+++ b/templates/express/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mydatabase:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 1024

--- a/templates/flask/files/.platform.app.yaml
+++ b/templates/flask/files/.platform.app.yaml
@@ -27,8 +27,8 @@ disk: 1024
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    redis: "redis:redis"
+    database: "db:mysql"
+    rediscache: "cache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/flask/files/.platform/services.yaml
+++ b/templates/flask/files/.platform/services.yaml
@@ -1,6 +1,6 @@
-mysqldb:
-  type: "mysql:10.2"
+db:
+  type: 'mariadb:10.2'
   disk: 2048
 
-redis:
-  type: "redis:3.2"
+cache:
+  type: 'redis:5.0'

--- a/templates/gin/files/.platform.app.yaml
+++ b/templates/gin/files/.platform.app.yaml
@@ -21,7 +21,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/gin/files/.platform/services.yaml
+++ b/templates/gin/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 1024

--- a/templates/golang/files/.platform.app.yaml
+++ b/templates/golang/files/.platform.app.yaml
@@ -21,7 +21,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/golang/files/.platform/services.yaml
+++ b/templates/golang/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 1024

--- a/templates/govcms8/files/.platform.app.yaml
+++ b/templates/govcms8/files/.platform.app.yaml
@@ -27,16 +27,26 @@ runtime:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
-    '/web/sites/default/files': 'shared:files/files'
-    '/tmp': 'shared:files/tmp'
-    '/private': 'shared:files/private'
-    '/.drush': 'shared:files/.drush'
-    '/drush-backups': 'shared:files/drush-backups'
-    '/.console': 'shared:files/console'
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    '/.console':
+        source: local
+        source_path: 'console'
 
 # Configuration of the build of this application.
 build:

--- a/templates/govcms8/files/.platform.app.yaml
+++ b/templates/govcms8/files/.platform.app.yaml
@@ -15,9 +15,9 @@ type: 'php:7.2'
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: 'mysqldb:mysql'
+    database: 'db:mysql'
 ## Uncomment this line to enable Redis caching for Drupal.
-#    redis: 'rediscache:redis'
+#    redis: 'cache:redis'
 
 # Add additional PHP extensions.
 runtime:

--- a/templates/govcms8/files/.platform/services.yaml
+++ b/templates/govcms8/files/.platform/services.yaml
@@ -3,13 +3,9 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048
-#
-#rediscache:
-#    type: redis:3.2
-#
-#solrsearch:
-#    type: solr:6.6
-#    disk: 1024
+
+cache:
+  type: "redis:5.0"

--- a/templates/koa/files/.platform.app.yaml
+++ b/templates/koa/files/.platform.app.yaml
@@ -12,7 +12,7 @@ type: nodejs:10
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-  database: "mydatabase:mysql"
+  database: "db:mysql"
 
 # The configuration of the application when it is exposed to the web.
 web:

--- a/templates/koa/files/.platform/services.yaml
+++ b/templates/koa/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mydatabase:
-    type: mysql:10.2
+db:
+    type: 'mariadb:10.2'
     disk: 1024

--- a/templates/laravel/files/.platform.app.yaml
+++ b/templates/laravel/files/.platform.app.yaml
@@ -24,9 +24,9 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    rediscache: "redis:redis"
-    redissession: "redis:redis"
+    database: "db:mysql"
+    rediscache: "cache:redis"
+    redissession: "cache:redis"
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/templates/laravel/files/.platform.app.yaml
+++ b/templates/laravel/files/.platform.app.yaml
@@ -33,13 +33,27 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-  "storage/app/public": "shared:files/public"
-  "storage/framework/views": "shared:files/views"
-  "storage/framework/sessions": "shared:files/sessions"
-  "storage/framework/cache": "shared:files/cache"
-  "storage/logs": "shared:files/logs"
-  "bootstrap/cache": "shared:files/bootstrap/cache"
-  "/.config": "shared:files/config"
+  "storage/app/public":
+      source: local
+      source_path: "public"
+  "storage/framework/views":
+      source: local
+      source_path: "views"
+  "storage/framework/sessions":
+      source: local
+      source_path: "sessions"
+  "storage/framework/cache":
+      source: local
+      source_path: "cache"
+  "storage/logs":
+      source: local
+      source_path: "logs"
+  "bootstrap/cache":
+      source: local
+      source_path: "cache"
+  "/.config":
+      source: local
+      source_path: "config"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/laravel/files/.platform/services.yaml
+++ b/templates/laravel/files/.platform/services.yaml
@@ -1,6 +1,6 @@
-mysqldb:
-  type: mysql:10.2
+db:
+  type: mariadb:10.2
   disk: 2048
 
-redis:
+cache:
     type: redis:5.0

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -24,8 +24,8 @@ build:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: mysqldb:mysql
-    redis: rediscache:redis
+    database: db:mysql
+    redis: cache:redis
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -30,15 +30,23 @@ relationships:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
-    "/var": "shared:files/var"
-    "/generated": "shared:files/generated"
-    "/pub/media": "shared:files/media"
-    "/pub/static": "shared:files/static"
-    "/.config": "shared:files/config"
+    "/var":
+        source: local
+        source_path: "var"
+    "/generated":
+        source: local
+        source_path: "generated"
+    "/pub/media":
+        source: local
+        source_path: "media"
+    "/pub/static":
+        source: local
+        source_path: "static"
+    "/.config":
+        source: local
+        source_path: "config"
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:

--- a/templates/magento2ce/files/.platform/services.yaml
+++ b/templates/magento2ce/files/.platform/services.yaml
@@ -1,6 +1,6 @@
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048
 
-rediscache:
+cache:
     type: redis:3.2

--- a/templates/microprofile-helidon/files/.platform.app.yaml
+++ b/templates/microprofile-helidon/files/.platform.app.yaml
@@ -21,7 +21,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "database:mysql"
+#    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/microprofile-helidon/files/.platform/services.yaml
+++ b/templates/microprofile-helidon/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-#database:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 1024

--- a/templates/microprofile-kumuluzee/files/.platform.app.yaml
+++ b/templates/microprofile-kumuluzee/files/.platform.app.yaml
@@ -26,7 +26,7 @@ mounts:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "database:mysql"
+#    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/microprofile-kumuluzee/files/.platform/services.yaml
+++ b/templates/microprofile-kumuluzee/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-#database:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 1024

--- a/templates/microprofile-openliberty/files/.platform.app.yaml
+++ b/templates/microprofile-openliberty/files/.platform.app.yaml
@@ -17,7 +17,6 @@ hooks:
        mvn clean package
 
 mounts:
-
     'server/':
         source: local
         source_path: server_source
@@ -32,7 +31,7 @@ mounts:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "database:mysql"
+#    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/microprofile-openliberty/files/.platform/services.yaml
+++ b/templates/microprofile-openliberty/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-#database:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 1024

--- a/templates/microprofile-payara/files/.platform.app.yaml
+++ b/templates/microprofile-payara/files/.platform.app.yaml
@@ -22,7 +22,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "database:mysql"
+#    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/microprofile-payara/files/.platform/services.yaml
+++ b/templates/microprofile-payara/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-#database:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 1024

--- a/templates/microprofile-thorntail/files/.platform.app.yaml
+++ b/templates/microprofile-thorntail/files/.platform.app.yaml
@@ -21,7 +21,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "database:mysql"
+#    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/microprofile-thorntail/files/.platform/services.yaml
+++ b/templates/microprofile-thorntail/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-#database:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 1024

--- a/templates/microprofile-tomee/files/.platform.app.yaml
+++ b/templates/microprofile-tomee/files/.platform.app.yaml
@@ -31,7 +31,7 @@ mounts:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "database:mysql"
+#    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/microprofile-tomee/files/.platform/services.yaml
+++ b/templates/microprofile-tomee/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-#database:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 1024

--- a/templates/opigno/files/.platform.app.yaml
+++ b/templates/opigno/files/.platform.app.yaml
@@ -27,16 +27,26 @@ runtime:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
-    '/web/sites/default/files': 'shared:files/files'
-    '/tmp': 'shared:files/tmp'
-    '/private': 'shared:files/private'
-    '/.drush': 'shared:files/.drush'
-    '/drush-backups': 'shared:files/drush-backups'
-    '/.console': 'shared:files/console'
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    '/.console':
+        source: local
+        source_path: 'console'
 
 # Configuration of the build of this application.
 build:

--- a/templates/opigno/files/.platform.app.yaml
+++ b/templates/opigno/files/.platform.app.yaml
@@ -15,9 +15,9 @@ type: 'php:7.2'
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: 'mysqldb:mysql'
+    database: 'db:mysql'
 ## Uncomment this line to enable Redis caching for Drupal.
-#    redis: 'rediscache:redis'
+#    redis: 'cache:redis'
 
 # Add additional PHP extensions.
 runtime:

--- a/templates/opigno/files/.platform/services.yaml
+++ b/templates/opigno/files/.platform/services.yaml
@@ -3,9 +3,9 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048
 
-rediscache:
+cache:
     type: redis:5.0

--- a/templates/php/files/.platform.app.yaml
+++ b/templates/php/files/.platform.app.yaml
@@ -22,7 +22,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 #relationships:
-#    database: "mysqldb:mysql"
+#    database: "db:mysql"
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/templates/php/files/.platform/services.yaml
+++ b/templates/php/files/.platform/services.yaml
@@ -1,5 +1,5 @@
 # This file defines services you want available to your application.
 
-#mysqldb:
-#    type: mysql:10.2
+#db:
+#    type: mariadb:10.2
 #    disk: 2048

--- a/templates/pimcore/files/.platform.app.yaml
+++ b/templates/pimcore/files/.platform.app.yaml
@@ -15,8 +15,8 @@ type: php:7.3
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-  database: "mysqldb:mysql"
-  redis: 'rediscache:redis'
+  database: "db:mysql"
+  redis: 'cache:redis'
 
 build:
   flavor: none

--- a/templates/pimcore/files/.platform.app.yaml
+++ b/templates/pimcore/files/.platform.app.yaml
@@ -37,9 +37,7 @@ variables:
   php:
       memory_limit: 128M
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
     "/var":
       source: "local"

--- a/templates/pimcore/files/.platform/services.yaml
+++ b/templates/pimcore/files/.platform/services.yaml
@@ -2,9 +2,9 @@
 #
 # Each service listed will be deployed
 # to power your Platform.sh project.
-mysqldb:
+db:
   type: mariadb:10.2
   disk: 2048
 
-rediscache:
+cache:
     type: redis:5.0

--- a/templates/pyramid/files/.platform.app.yaml
+++ b/templates/pyramid/files/.platform.app.yaml
@@ -26,8 +26,8 @@ disk: 1024
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    redis: "redis:redis"
+    database: "db:mysql"
+    redis: "cache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/pyramid/files/.platform/services.yaml
+++ b/templates/pyramid/files/.platform/services.yaml
@@ -1,6 +1,6 @@
-mysqldb:
-  type: "mysql:10.2"
+db:
+  type: "mariadb:10.2"
   disk: 2048
 
-redis:
+cache:
   type: "redis:3.2"

--- a/templates/python2/files/.platform.app.yaml
+++ b/templates/python2/files/.platform.app.yaml
@@ -23,8 +23,8 @@ disk: 1024
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    redis: "redis:redis"
+    database: "db:mysql"
+    redis: "cache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/python2/files/.platform/services.yaml
+++ b/templates/python2/files/.platform/services.yaml
@@ -1,6 +1,6 @@
-mysqldb:
-  type: "mysql:10.2"
+db:
+  type: "mariadb:10.2"
   disk: 2048
 
-redis:
+cache:
   type: "redis:5.0"

--- a/templates/python3/files/.platform.app.yaml
+++ b/templates/python3/files/.platform.app.yaml
@@ -27,8 +27,8 @@ disk: 1024
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    redis: "redis:redis"
+    database: "db:mysql"
+    redis: "cache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/python3/files/.platform/services.yaml
+++ b/templates/python3/files/.platform/services.yaml
@@ -1,6 +1,6 @@
-mysqldb:
-  type: "mysql:10.2"
+db:
+  type: "mariadb:10.2"
   disk: 2048
 
-redis:
+cache:
   type: "redis:5.0"

--- a/templates/python3_uwsgi/files/.platform.app.yaml
+++ b/templates/python3_uwsgi/files/.platform.app.yaml
@@ -25,8 +25,8 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
-    redis: "redis:redis"
+    database: "db:mysql"
+    redis: "cache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/python3_uwsgi/files/.platform/services.yaml
+++ b/templates/python3_uwsgi/files/.platform/services.yaml
@@ -4,10 +4,10 @@
 # Platform.sh project.
 #
 # See https://docs.platform.sh/configuration/services.html
-mysqldb:
-  type: "mysql:10.2"
+db:
+  type: "mariadb:10.2"
   disk: 2048
 
-redis:
+cache:
   type: "redis:5.0"
 

--- a/templates/rails/files/.platform.app.yaml
+++ b/templates/rails/files/.platform.app.yaml
@@ -29,9 +29,7 @@ variables:
         RAILS_TMP: /tmp
         EXECJS_RUNTIME: 'Node'
 
-# The 'mounts' describe writable, persistent filesystem mounts in the application. The keys are
-# directory paths, relative to the application root. The values are strings such as
-# 'shared:files/PATH', where PATH is a relative path under the mount's source directory.
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
     "/log":
         source: local

--- a/templates/rails/files/.platform.app.yaml
+++ b/templates/rails/files/.platform.app.yaml
@@ -15,7 +15,7 @@ type: "ruby:2.6"
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: 'postgresqldb:postgresql'
+    database: 'db:postgresql'
 
 # The size of the persistent disk of the application (in MB).
 disk: 1024

--- a/templates/rails/files/.platform/services.yaml
+++ b/templates/rails/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-postgresqldb:
+db:
     type: postgresql:11
     disk: 1024

--- a/templates/spring-boot-gradle-mysql/files/.platform.app.yaml
+++ b/templates/spring-boot-gradle-mysql/files/.platform.app.yaml
@@ -22,7 +22,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "database:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/spring-boot-gradle-mysql/files/.platform/services.yaml
+++ b/templates/spring-boot-gradle-mysql/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-database:
+db:
     type: oracle-mysql:8.0
     disk: 1024

--- a/templates/spring-boot-maven-mysql/files/.platform.app.yaml
+++ b/templates/spring-boot-maven-mysql/files/.platform.app.yaml
@@ -22,7 +22,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "database:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/spring-boot-maven-mysql/files/.platform/services.yaml
+++ b/templates/spring-boot-maven-mysql/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-database:
+db:
     type: oracle-mysql:8.0
     disk: 1024

--- a/templates/spring-mvc-maven-mongodb/files/.platform.app.yaml
+++ b/templates/spring-mvc-maven-mongodb/files/.platform.app.yaml
@@ -21,7 +21,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "database:mongodb"
+    database: "db:mongodb"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/spring-mvc-maven-mongodb/files/.platform/services.yaml
+++ b/templates/spring-mvc-maven-mongodb/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-database:
+db:
     type: mongodb:3.6
     disk: 1024

--- a/templates/symfony3/files/.platform.app.yaml
+++ b/templates/symfony3/files/.platform.app.yaml
@@ -36,9 +36,15 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-    "/var/cache": "shared:files/cache"
-    "/var/logs": "shared:files/logs"
-    "/var/sessions": "shared:files/sessions"
+    "/var/cache":
+        source: local
+        source_path: "cache"
+    "/var/logs":
+        source: local
+        source_path: "logs"
+    "/var/sessions":
+        source: local
+        source_path: "sessions"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/symfony3/files/.platform.app.yaml
+++ b/templates/symfony3/files/.platform.app.yaml
@@ -29,7 +29,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/templates/symfony3/files/.platform/services.yaml
+++ b/templates/symfony3/files/.platform/services.yaml
@@ -1,3 +1,3 @@
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048

--- a/templates/symfony4/files/.platform.app.yaml
+++ b/templates/symfony4/files/.platform.app.yaml
@@ -38,9 +38,15 @@ disk: 2048
 
 # The mounts that will be performed when the package is deployed.
 mounts:
-    "/var/cache": "shared:files/cache"
-    "/var/log": "shared:files/log"
-    "/var/sessions": "shared:files/sessions"
+    "/var/cache":
+        source: local
+        source_path: "cache"
+    "/var/log":
+        source: local
+        source_path: "log"
+    "/var/sessions":
+        source: local
+        source_path: "sessions"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/symfony4/files/.platform.app.yaml
+++ b/templates/symfony4/files/.platform.app.yaml
@@ -31,7 +31,7 @@ hooks:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/templates/symfony4/files/.platform/services.yaml
+++ b/templates/symfony4/files/.platform/services.yaml
@@ -1,3 +1,3 @@
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048

--- a/templates/wagtail/files/.platform.app.yaml
+++ b/templates/wagtail/files/.platform.app.yaml
@@ -20,7 +20,7 @@ dependencies:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "postgresqldb:postgresql"
+    database: "db:postgresql"
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -55,7 +55,7 @@ hooks:
   build: |
     pipenv install --system --deploy
     pip install wagtail
-    
+
     mkdir logs
     python manage.py collectstatic
     rm -rf logs

--- a/templates/wagtail/files/.platform/services.yaml
+++ b/templates/wagtail/files/.platform/services.yaml
@@ -5,6 +5,6 @@
 #
 # See https://docs.platform.sh/user_guide/reference/services-yaml.html
 
-postgresqldb:
+db:
     type: postgresql:10
     disk: 1024

--- a/templates/wordpress/files/.platform.app.yaml
+++ b/templates/wordpress/files/.platform.app.yaml
@@ -55,7 +55,12 @@ dependencies:
     php:
         wp-cli/wp-cli: "^2.2.0"
         psy/psysh: "^0.8.4"
+
 # The mounts that will be performed when the package is deployed.
 mounts:
-    "web/wp-content/cache": "shared:files/cache"
-    "web/wp-content/uploads": "shared:files/uploads"
+    "web/wp-content/cache":
+        source: local
+        source_path: "cache"
+    "web/wp-content/uploads":
+        source: local
+        source_path: "uploads"

--- a/templates/wordpress/files/.platform.app.yaml
+++ b/templates/wordpress/files/.platform.app.yaml
@@ -16,7 +16,7 @@ build:
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
-    database: "mysqldb:mysql"
+    database: "db:mysql"
 
 # The configuration of app when it is exposed to the web.
 web:

--- a/templates/wordpress/files/.platform/services.yaml
+++ b/templates/wordpress/files/.platform/services.yaml
@@ -3,6 +3,6 @@
 # Each service listed will be deployed
 # to power your Platform.sh project.
 
-mysqldb:
-    type: mysql:10.2
+db:
+    type: mariadb:10.2
     disk: 2048


### PR DESCRIPTION
* Switch all `mysql` services to `mariadb`.
* Rename all services per new convention.
* Use new-style mount syntax, as it turns out that does work on PE now.

I did NOT mess with the existing relationship names, as that may require code changes and I didn't want to go there.

I have not tried building, as that will require rebuilding about 30 projects and... that's not fun.