### PR TITLE
Include a check in Drupal Redis integration

### DIFF
--- a/templates/drupal8/files/web/sites/default/settings.platformsh.php
+++ b/templates/drupal8/files/web/sites/default/settings.platformsh.php
@@ -23,7 +23,7 @@ $databases['default']['default'] = [
 ];
 
 // Enable Redis caching.
-if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() && extension_loaded('redis')) {
+if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {
   $redis = $platformsh->credentials('redis');
 
   // Set Redis as the default backend for any cache bin not otherwise specified.

--- a/templates/drupal8multi/files/web/sites/settings.platformsh.php
+++ b/templates/drupal8multi/files/web/sites/settings.platformsh.php
@@ -29,7 +29,7 @@ if ($creds) {
 }
 
 // Enable Redis caching.
-if (!empty($platformsh_enable_redis) && $platformsh->hasRelationship('rediscache') && !drupal_installation_attempted() && extension_loaded('redis')) {
+if (!empty($platformsh_enable_redis) && $platformsh->hasRelationship('rediscache') && !drupal_installation_attempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {
   $redis = $platformsh->credentials('rediscache');
 
   // Set a cache prefix so not all sites go into the same cache pool.

--- a/templates/opigno/files/web/sites/default/settings.platformsh.php
+++ b/templates/opigno/files/web/sites/default/settings.platformsh.php
@@ -23,7 +23,7 @@ $databases['default']['default'] = [
 ];
 
 // Enable Redis caching.
-if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() && extension_loaded('redis')) {
+if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() && extension_loaded('redis') && class_exists('Drupal\redis\ClientFactory')) {
   $redis = $platformsh->credentials('redis');
 
   // Set Redis as the default backend for any cache bin not otherwise specified.


### PR DESCRIPTION
 in case the Redis module itself is missing.

cf:
https://github.com/platformsh/template-drupal8/pull/51
https://github.com/platformsh/template-opigno/pull/3
https://github.com/platformsh/template-drupal8multi/pull/5

(govcms8 not included because it's settings.platformsh.php file is well behind anyway and it has other issues that need fixing first.)