### PR TITLE
Refine Drush URL selection

### DIFF
--- a/templates/drupal8/files/drush/platformsh_drush.inc
+++ b/templates/drupal8/files/drush/platformsh_drush.inc
@@ -20,28 +20,30 @@ function _platformsh_drush_site_url() {
   // Filter the list of routes to find those matching the current app.
   $appUrls = [];
   foreach ($routes as $url => $route) {
-    if ($route['type'] === 'upstream' && $route['upstream'] === $appName) {
-      $appUrls[$route['original_url']] = $url;
+    if ($route['type'] === 'upstream' && strpos($route['upstream'], $appName . ':') === 0) {
+      // If this route is the primary one, use its URL directly.
+      if (!empty($route['primary'])) {
+        return $url;
+      }
+
+      // Otherwise, add it to the list.
+      $appUrls[] = $url;
     }
   }
 
-  // Select the first preferred route, if it exists in the app URLs.
-  $preferred_routes = [
-    'https://{default}/',
-    'https://{default}',
-    'https://www.{default}/',
-    'https://www.{default}',
-    'https://{all}/',
-    'https://{all}',
-    'https://www.{all}/',
-    'https://www.{all}',
-  ];
-  foreach ($preferred_routes as $preferred_route) {
-    if (isset($appUrls[$preferred_route])) {
-      return $appUrls[$preferred_route];
+  // Sort the URLs, preferring shorter ones with HTTPS.
+  usort($appUrls, function ($a, $b) {
+    $result = 0;
+    foreach ([$a, $b] as $key => $url) {
+      if (strpos($url, 'https://') === 0) {
+        $result += $key === 0 ? -2 : 2;
+      }
     }
-  }
+    $result += strlen($a) <= strlen($b) ? -1 : 1;
 
-  // Otherwise, return the first URL that matched the app.
+    return $result;
+  });
+  
+  // Return the first one.
   return reset($appUrls) ?: NULL;
 }


### PR DESCRIPTION
- Fix upstream name match to accommodate the `:http` suffix
- Prefer the primary route
- Sort URLs rather than the list of preferred "original URLs"