### PR TITLE
Clean up and expand config reader usage in Drupal

### DIFF
--- a/templates/drupal8/files/drush/platformsh_drush.inc
+++ b/templates/drupal8/files/drush/platformsh_drush.inc
@@ -20,28 +20,30 @@ function _platformsh_drush_site_url() {
   // Filter the list of routes to find those matching the current app.
   $appUrls = [];
   foreach ($routes as $url => $route) {
-    if ($route['type'] === 'upstream' && $route['upstream'] === $appName) {
-      $appUrls[$route['original_url']] = $url;
+    if ($route['type'] === 'upstream' && strpos($route['upstream'], $appName . ':') === 0) {
+      // If this route is the primary one, use its URL directly.
+      if (!empty($route['primary'])) {
+        return $url;
+      }
+
+      // Otherwise, add it to the list.
+      $appUrls[] = $url;
     }
   }
 
-  // Select the first preferred route, if it exists in the app URLs.
-  $preferred_routes = [
-    'https://{default}/',
-    'https://{default}',
-    'https://www.{default}/',
-    'https://www.{default}',
-    'https://{all}/',
-    'https://{all}',
-    'https://www.{all}/',
-    'https://www.{all}',
-  ];
-  foreach ($preferred_routes as $preferred_route) {
-    if (isset($appUrls[$preferred_route])) {
-      return $appUrls[$preferred_route];
+  // Sort the URLs, preferring shorter ones with HTTPS.
+  usort($appUrls, function ($a, $b) {
+    $result = 0;
+    foreach ([$a, $b] as $key => $url) {
+      if (strpos($url, 'https://') === 0) {
+        $result += $key === 0 ? -2 : 2;
+      }
     }
-  }
+    $result += strlen($a) <= strlen($b) ? -1 : 1;
 
-  // Otherwise, return the first URL that matched the app.
+    return $result;
+  });
+  
+  // Return the first one.
   return reset($appUrls) ?: NULL;
 }

--- a/templates/drupal8/files/drush/platformsh_drush.inc
+++ b/templates/drupal8/files/drush/platformsh_drush.inc
@@ -16,14 +16,17 @@ function _platformsh_drush_site_url() {
     return;
   }
 
-  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
+  $routes = $platformsh->getUpstreamRoutes($appName);
 
-  // Sort the URLs, preferring shorter ones with HTTPS.
-  usort($appUrls, function (array $a, array $b) {
+  // Sort URLs, with the primary route first, then by HTTPS before HTTP, then by length.
+  usort($routes, function (array $a, array $b) {
     // false sorts before true, normally, so negate the comparison.
-    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+    return
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($a['url'])]
+      <=>
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($b['url'])];
   });
 
-  // Return the first one.
-  return reset($appUrls) ?: NULL;
+  // Return the url of the first one.
+  return reset($appUrls)['url'] ?: NULL;
 }

--- a/templates/drupal8/files/drush/platformsh_drush.inc
+++ b/templates/drupal8/files/drush/platformsh_drush.inc
@@ -10,40 +10,20 @@
  * @return string|NULL
  */
 function _platformsh_drush_site_url() {
-  if (!getenv('PLATFORM_ROUTES') || !getenv('PLATFORM_APPLICATION_NAME')) {
-    return NULL;
+  $platformsh = new \Platformsh\ConfigReader\Config();
+
+  if (!$platformsh->inRuntime()) {
+    return;
   }
 
-  $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
-  $appName = getenv('PLATFORM_APPLICATION_NAME');
-
-  // Filter the list of routes to find those matching the current app.
-  $appUrls = [];
-  foreach ($routes as $url => $route) {
-    if ($route['type'] === 'upstream' && strpos($route['upstream'], $appName . ':') === 0) {
-      // If this route is the primary one, use its URL directly.
-      if (!empty($route['primary'])) {
-        return $url;
-      }
-
-      // Otherwise, add it to the list.
-      $appUrls[] = $url;
-    }
-  }
+  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
 
   // Sort the URLs, preferring shorter ones with HTTPS.
-  usort($appUrls, function ($a, $b) {
-    $result = 0;
-    foreach ([$a, $b] as $key => $url) {
-      if (strpos($url, 'https://') === 0) {
-        $result += $key === 0 ? -2 : 2;
-      }
-    }
-    $result += strlen($a) <= strlen($b) ? -1 : 1;
-
-    return $result;
+  usort($appUrls, function (array $a, array $b) {
+    // false sorts before true, normally, so negate the comparison.
+    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
   });
-  
+
   // Return the first one.
   return reset($appUrls) ?: NULL;
 }

--- a/templates/drupal8multi/.platform.template.yaml
+++ b/templates/drupal8multi/.platform.template.yaml
@@ -39,7 +39,7 @@ info:
   # Each note object is displayed as a small section heading with content below. Supports limited HTML.
   notes:
     - heading: "Apps & Services"
-      content: "PHP 7.3<br/>MariaDB 10.2<br />Redis 5.0"
+      content: "PHP 7.2<br/>MariaDB 10.2<br />Redis 5.0"
 
 
 # This key describes the initialization call made to the master environment at

--- a/templates/drupal8multi/files/README.md
+++ b/templates/drupal8multi/files/README.md
@@ -6,7 +6,7 @@ Drupal is a flexible and extensible PHP-based CMS framework capable of hosting m
 
 ## Services
 
-* PHP 7.3
+* PHP 7.2
 * MariaDB 10.2
 * Redis 5
 
@@ -34,7 +34,7 @@ Multisite on Platform.sh can be tricky.  Drupal multisite bases its logic off of
 
 * Every subsite is a subdomain off of a common domain.  See `routes.yaml`.  The domain prefix is the "subsite ID".
 * Every subsite has its own database and endpoint on a single MariaDB service instance.  The endpoint name is the same as the subsite ID.
-* The `sites/sites.php` file includes code to build a `$sites` lookup list to map any incoming request, regardless of branch, to a settings directory named for the subsite ID.  It consists of two parts: The first block filters the routes list from the environment to just those that are relevant (that is, it excludes redirect routes or routes that point to a different application container).  The second parses those routes into a domain name -> directory list, where the directory is the site ID.  You will also most never want to modify the first part.  The second part you may want to modify if you are not using a subdomain model.
+* The `sites/sites.php` file includes code to build a `$sites` lookup list to map any incoming request, regardless of branch, to a settings directory named for the subsite ID.  It iterates over all routes that point to the Drupal application and parses those routes into a domain name -> directory list, where the directory is the site ID.  If you are not using a subdomain based multi-site you will likely need to modify the body of the `foreach()` loop.
 * The `.platform.app.yaml` file is essentially the same as for a single-site Drupal installation, but its relationships include every defined MariaDB endpoint.  The relationship is also named for the subsite ID.
 * Every subsite ID's `settings.php` file is identical, and largely similar to the standard Platform.sh `settings.php` file.  You may customize it if needed.  In particular, the `$platformsh_enable_redis` variable should be toggled to `true` for each site only after the install process is completed for that site, as Drupal cannot install with the redis module active.
 * The `settings.php` files also include a shared `sites/settings.platformsh.php` file.  It is largely the same as in a single-site configuration but has been modified to leverage the subsite ID for:

--- a/templates/drupal8multi/files/drush/platformsh_drush.inc
+++ b/templates/drupal8multi/files/drush/platformsh_drush.inc
@@ -10,38 +10,20 @@
  * @return string|NULL
  */
 function _platformsh_drush_site_url() {
-  if (!getenv('PLATFORM_ROUTES') || !getenv('PLATFORM_APPLICATION_NAME')) {
-    return NULL;
+  $platformsh = new \Platformsh\ConfigReader\Config();
+
+  if (!$platformsh->inRuntime()) {
+    return;
   }
 
-  $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
-  $appName = getenv('PLATFORM_APPLICATION_NAME');
+  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
 
-  // Filter the list of routes to find those matching the current app.
-  $appUrls = [];
-  foreach ($routes as $url => $route) {
-    if ($route['type'] === 'upstream' && $route['upstream'] === $appName) {
-      $appUrls[$route['original_url']] = $url;
-    }
-  }
+  // Sort the URLs, preferring shorter ones with HTTPS.
+  usort($appUrls, function (array $a, array $b) {
+    // false sorts before true, normally, so negate the comparison.
+    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+  });
 
-  // Select the first preferred route, if it exists in the app URLs.
-  $preferred_routes = [
-    'https://{default}/',
-    'https://{default}',
-    'https://www.{default}/',
-    'https://www.{default}',
-    'https://{all}/',
-    'https://{all}',
-    'https://www.{all}/',
-    'https://www.{all}',
-  ];
-  foreach ($preferred_routes as $preferred_route) {
-    if (isset($appUrls[$preferred_route])) {
-      return $appUrls[$preferred_route];
-    }
-  }
-
-  // Otherwise, return the first URL that matched the app.
+  // Return the first one.
   return reset($appUrls) ?: NULL;
 }

--- a/templates/drupal8multi/files/drush/platformsh_drush.inc
+++ b/templates/drupal8multi/files/drush/platformsh_drush.inc
@@ -16,14 +16,17 @@ function _platformsh_drush_site_url() {
     return;
   }
 
-  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
+  $routes = $platformsh->getUpstreamRoutes($appName);
 
-  // Sort the URLs, preferring shorter ones with HTTPS.
-  usort($appUrls, function (array $a, array $b) {
+  // Sort URLs, with the primary route first, then by HTTPS before HTTP, then by length.
+  usort($routes, function (array $a, array $b) {
     // false sorts before true, normally, so negate the comparison.
-    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+    return
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($a['url'])]
+      <=>
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($b['url'])];
   });
 
-  // Return the first one.
-  return reset($appUrls) ?: NULL;
+  // Return the url of the first one.
+  return reset($appUrls)['url'] ?: NULL;
 }

--- a/templates/drupal8multi/files/web/sites/settings.platformsh.php
+++ b/templates/drupal8multi/files/web/sites/settings.platformsh.php
@@ -104,20 +104,13 @@ if (!isset($settings['php_storage']['twig'])) {
   $settings['php_storage']['twig']['directory'] = $settings['file_private_path'];
 }
 
-// Set trusted hosts based on Platform.sh routes.
-if (!isset($settings['trusted_host_patterns'])) {
-  $routes = $platformsh->routes();
-  $patterns = [];
-  foreach ($routes as $url => $route) {
-    $host = parse_url($url, PHP_URL_HOST);
-    if ($host !== false && $route['type'] == 'upstream' && $route['upstream'] == $platformsh->applicationName) {
-      // Replace asterisk wildcards with a regular expression.
-      $host_pattern = str_replace('\*', '[^\.]+', preg_quote($host));
-      $patterns[] = '^' . $host_pattern . '$';
-    }
-  }
-  $settings['trusted_host_patterns'] = array_unique($patterns);
-}
+// The 'trusted_hosts_pattern' setting allows an admin to restrict the Host header values
+// that are considered trusted.  If an attacker sends a request with a custom-crafted Host
+// header then it can be an injection vector, depending on how the Host header is used.
+// However, Platform.sh already replaces the Host header with the route that was used to reach
+// Platform.sh, so it is guaranteed to be safe.  The following line explicitly allows all
+// Host headers, as the only possible Host header is already guaranteed safe.
+$settings['trusted_host_patterns'] = ['.*'];
 
 // Import variables prefixed with 'd8settings:' into $settings
 // and 'd8config:' into $config.

--- a/templates/drupal8multi/files/web/sites/sites.php
+++ b/templates/drupal8multi/files/web/sites/sites.php
@@ -60,16 +60,11 @@ if (!$platformsh->inRuntime()) {
   return;
 }
 
-$applicationName = $platformsh->applicationName;
-$relevantRoutes = array_filter($platformsh->routes(), function ($route) use ($applicationName) {
-  return $route['type'] == 'upstream' && $route['upstream'] == $applicationName;
-});
-
 // The following block adds a $sites[] entry for each subdomain that is defined
 // in routes.yaml.
 // If you are not using subdomain-based multisite routes then you will need to
 // adapt the code below accordingly.
-foreach ($relevantRoutes as $route) {
+foreach ($platformsh->getUpstreamRoutes($platformsh->applicationName) as $route) {
   $host = parse_url($route['url'], PHP_URL_HOST);
   if ($host !== FALSE) {
     $subdomain = substr($host, 0, strpos($host,'.'));

--- a/templates/govcms8/files/drush/platformsh_drush.inc
+++ b/templates/govcms8/files/drush/platformsh_drush.inc
@@ -10,38 +10,20 @@
  * @return string|NULL
  */
 function _platformsh_drush_site_url() {
-  if (!getenv('PLATFORM_ROUTES') || !getenv('PLATFORM_APPLICATION_NAME')) {
-    return NULL;
+  $platformsh = new \Platformsh\ConfigReader\Config();
+
+  if (!$platformsh->inRuntime()) {
+    return;
   }
 
-  $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
-  $appName = getenv('PLATFORM_APPLICATION_NAME');
+  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
 
-  // Filter the list of routes to find those matching the current app.
-  $appUrls = [];
-  foreach ($routes as $url => $route) {
-    if ($route['type'] === 'upstream' && $route['upstream'] === $appName) {
-      $appUrls[$route['original_url']] = $url;
-    }
-  }
+  // Sort the URLs, preferring shorter ones with HTTPS.
+  usort($appUrls, function (array $a, array $b) {
+    // false sorts before true, normally, so negate the comparison.
+    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+  });
 
-  // Select the first preferred route, if it exists in the app URLs.
-  $preferred_routes = [
-    'https://{default}/',
-    'https://{default}',
-    'https://www.{default}/',
-    'https://www.{default}',
-    'https://{all}/',
-    'https://{all}',
-    'https://www.{all}/',
-    'https://www.{all}',
-  ];
-  foreach ($preferred_routes as $preferred_route) {
-    if (isset($appUrls[$preferred_route])) {
-      return $appUrls[$preferred_route];
-    }
-  }
-
-  // Otherwise, return the first URL that matched the app.
+  // Return the first one.
   return reset($appUrls) ?: NULL;
 }

--- a/templates/govcms8/files/drush/platformsh_drush.inc
+++ b/templates/govcms8/files/drush/platformsh_drush.inc
@@ -16,14 +16,17 @@ function _platformsh_drush_site_url() {
     return;
   }
 
-  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
+  $routes = $platformsh->getUpstreamRoutes($appName);
 
-  // Sort the URLs, preferring shorter ones with HTTPS.
-  usort($appUrls, function (array $a, array $b) {
+  // Sort URLs, with the primary route first, then by HTTPS before HTTP, then by length.
+  usort($routes, function (array $a, array $b) {
     // false sorts before true, normally, so negate the comparison.
-    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+    return
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($a['url'])]
+      <=>
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($b['url'])];
   });
 
-  // Return the first one.
-  return reset($appUrls) ?: NULL;
+  // Return the url of the first one.
+  return reset($appUrls)['url'] ?: NULL;
 }

--- a/templates/govcms8/files/web/sites/default/settings.platformsh.php
+++ b/templates/govcms8/files/web/sites/default/settings.platformsh.php
@@ -58,20 +58,13 @@ if (getenv('PLATFORM_APP_DIR')) {
 
 }
 
-// Set trusted hosts based on Platform.sh routes.
-if (getenv('PLATFORM_ROUTES') && !isset($settings['trusted_host_patterns'])) {
-  $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
-  $settings['trusted_host_patterns'] = [];
-  foreach ($routes as $url => $route) {
-    $host = parse_url($url, PHP_URL_HOST);
-    if ($host !== FALSE && $route['type'] == 'upstream' && $route['upstream'] == getenv('PLATFORM_APPLICATION_NAME')) {
-      // Replace asterisk wildcards with a regular expression.
-      $host_pattern = str_replace('\*', '[^\.]+', preg_quote($host));
-      $settings['trusted_host_patterns'][] = '^' . $host_pattern . '$';
-    }
-  }
-  $settings['trusted_host_patterns'] = array_unique($settings['trusted_host_patterns']);
-}
+// The 'trusted_hosts_pattern' setting allows an admin to restrict the Host header values
+// that are considered trusted.  If an attacker sends a request with a custom-crafted Host
+// header then it can be an injection vector, depending on how the Host header is used.
+// However, Platform.sh already replaces the Host header with the route that was used to reach
+// Platform.sh, so it is guaranteed to be safe.  The following line explicitly allows all
+// Host headers, as the only possible Host header is already guaranteed safe.
+$settings['trusted_host_patterns'] = ['.*'];
 
 // Import variables prefixed with 'd8settings:' into $settings and 'd8config:'
 // into $config.

--- a/templates/opigno/files/drush/platformsh_drush.inc
+++ b/templates/opigno/files/drush/platformsh_drush.inc
@@ -10,38 +10,20 @@
  * @return string|NULL
  */
 function _platformsh_drush_site_url() {
-  if (!getenv('PLATFORM_ROUTES') || !getenv('PLATFORM_APPLICATION_NAME')) {
-    return NULL;
+  $platformsh = new \Platformsh\ConfigReader\Config();
+
+  if (!$platformsh->inRuntime()) {
+    return;
   }
 
-  $routes = json_decode(base64_decode(getenv('PLATFORM_ROUTES')), TRUE);
-  $appName = getenv('PLATFORM_APPLICATION_NAME');
+  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
 
-  // Filter the list of routes to find those matching the current app.
-  $appUrls = [];
-  foreach ($routes as $url => $route) {
-    if ($route['type'] === 'upstream' && $route['upstream'] === $appName) {
-      $appUrls[$route['original_url']] = $url;
-    }
-  }
+  // Sort the URLs, preferring shorter ones with HTTPS.
+  usort($appUrls, function (array $a, array $b) {
+    // false sorts before true, normally, so negate the comparison.
+    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+  });
 
-  // Select the first preferred route, if it exists in the app URLs.
-  $preferred_routes = [
-    'https://{default}/',
-    'https://{default}',
-    'https://www.{default}/',
-    'https://www.{default}',
-    'https://{all}/',
-    'https://{all}',
-    'https://www.{all}/',
-    'https://www.{all}',
-  ];
-  foreach ($preferred_routes as $preferred_route) {
-    if (isset($appUrls[$preferred_route])) {
-      return $appUrls[$preferred_route];
-    }
-  }
-
-  // Otherwise, return the first URL that matched the app.
+  // Return the first one.
   return reset($appUrls) ?: NULL;
 }

--- a/templates/opigno/files/drush/platformsh_drush.inc
+++ b/templates/opigno/files/drush/platformsh_drush.inc
@@ -16,14 +16,17 @@ function _platformsh_drush_site_url() {
     return;
   }
 
-  $appUrls = array_keys($platformsh->getUpstreamRoutes($appName));
+  $routes = $platformsh->getUpstreamRoutes($appName);
 
-  // Sort the URLs, preferring shorter ones with HTTPS.
-  usort($appUrls, function (array $a, array $b) {
+  // Sort URLs, with the primary route first, then by HTTPS before HTTP, then by length.
+  usort($routes, function (array $a, array $b) {
     // false sorts before true, normally, so negate the comparison.
-    return [strpos($a, 'https://') !== 0, strlen($a)] <=> [strpos($a, 'https://') !== 0, strlen($b)];
+    return
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($a['url'])]
+      <=>
+      [!$a['primary'], strpos($a['url'], 'https://') !== 0, strlen($b['url'])];
   });
 
-  // Return the first one.
-  return reset($appUrls) ?: NULL;
+  // Return the url of the first one.
+  return reset($appUrls)['url'] ?: NULL;
 }

--- a/templates/opigno/files/web/sites/default/settings.platformsh.php
+++ b/templates/opigno/files/web/sites/default/settings.platformsh.php
@@ -92,20 +92,13 @@ if (!isset($settings['php_storage']['twig'])) {
   $settings['php_storage']['twig']['directory'] = $settings['file_private_path'];
 }
 
-// Set trusted hosts based on Platform.sh routes.
-if (!isset($settings['trusted_host_patterns'])) {
-  $routes = $platformsh->routes();
-  $patterns = [];
-  foreach ($routes as $url => $route) {
-    $host = parse_url($url, PHP_URL_HOST);
-    if ($host !== FALSE && $route['type'] == 'upstream' && $route['upstream'] == $platformsh->applicationName) {
-      // Replace asterisk wildcards with a regular expression.
-      $host_pattern = str_replace('\*', '[^\.]+', preg_quote($host));
-      $patterns[] = '^' . $host_pattern . '$';
-    }
-  }
-  $settings['trusted_host_patterns'] = array_unique($patterns);
-}
+// The 'trusted_hosts_pattern' setting allows an admin to restrict the Host header values
+// that are considered trusted.  If an attacker sends a request with a custom-crafted Host
+// header then it can be an injection vector, depending on how the Host header is used.
+// However, Platform.sh already replaces the Host header with the route that was used to reach
+// Platform.sh, so it is guaranteed to be safe.  The following line explicitly allows all
+// Host headers, as the only possible Host header is already guaranteed safe.
+$settings['trusted_host_patterns'] = ['.*'];
 
 // Import variables prefixed with 'd8settings:' into $settings
 // and 'd8config:' into $config.


### PR DESCRIPTION
* Update the Drush URL derivation.
* Remove all trusted-host logic as it's no longer needed.
* Use the new config reader functionality in the D8 multisite logic.

Related:

* https://github.com/platformsh/template-drupal8/pull/52
* https://github.com/platformsh/template-drupal8multi/pull/6
* https://github.com/platformsh/template-opigno/pull/4
* No GovCMS8 yet as that still needs work for other reasons