### PR TITLE
Fix multiple bugs in the latest-tag derivation logic. 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ autopep8 = "*"
 
 [packages]
 doit = "*"
+packaging = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4ef1813b234c82a31f6a21a5ebeb7c7b22a72d94c385b291f1d765c282b3ae60"
+            "sha256": "0a7d563d109bde3b69dd11b5c21a07c9a4d886a3a9831662ba5ba8ee9601dd69"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,17 +18,26 @@
     "default": {
         "cloudpickle": {
             "hashes": [
-                "sha256:603244e0f552b72a267d47a7d9b347b27a3430f58a0536037a290e7e0e212ecf",
-                "sha256:b8ba7e322f2394b9bbbdc1c976e6442c2c02acc784cb9e553cee9186166a6890"
+                "sha256:922401d7140e133253ff5fab4faa4a1166416066453a783b00b507dca93f8859",
+                "sha256:f3ef2c9d438f1553ce7795afb18c1f190d8146132496169ef6aa9b7b65caa4c3"
             ],
-            "version": "==1.2.1"
+            "version": "==1.2.2"
         },
         "doit": {
             "hashes": [
                 "sha256:52b7ad1c0095425bd719c2fc9fb27af94fb0ee478762c50abf385faaf786d010",
                 "sha256:bad01949effd537cade3aea286cc2cde074bdb7a4f442015557b1228dd46f5ea"
             ],
+            "index": "pypi",
             "version": "==0.31.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+            ],
+            "index": "pypi",
+            "version": "==19.2"
         },
         "pyinotify": {
             "hashes": [
@@ -36,20 +45,35 @@
             ],
             "markers": "sys_platform == 'linux'",
             "version": "==0.9.6"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+            ],
+            "version": "==2.4.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
-                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
+                "sha256:98c665ad84d10b18318c5ab7c3d203fe11714cbad2a4aef4f44651f415392754",
+                "sha256:b7546ffdedbf7abcfbff93cd1de9e9980b1ef744852689decc5aeada324238c6"
             ],
-            "version": "==2.2.5"
+            "version": "==2.3.1"
         },
         "autopep8": {
             "hashes": [
                 "sha256:4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"
             ],
+            "index": "pypi",
             "version": "==1.4.4"
         },
         "isort": {
@@ -98,10 +122,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
-                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+                "sha256:7edbae11476c2182708063ac387a8f97c760d9cfe36a5ede0ca996f90cf346c8",
+                "sha256:844ce067788028c1a35086a5c66bc5e599ddd851841c41d6ee1623b36774d9f2"
             ],
-            "version": "==2.3.1"
+            "index": "pypi",
+            "version": "==2.4.2"
         },
         "six": {
             "hashes": [
@@ -128,7 +153,7 @@
                 "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
                 "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
             ],
-            "markers": "implementation_name == 'cpython'",
+            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.0"
         },
         "wrapt": {

--- a/project/remote.py
+++ b/project/remote.py
@@ -1,5 +1,6 @@
 from . import BaseProject
 import subprocess
+import packaging.version
 
 class RemoteProject(BaseProject):
     '''
@@ -35,6 +36,7 @@ class RemoteProject(BaseProject):
         if hasattr(self, 'major_version'):
             def merge_from_upstream_tag():
                 latest_tag = self.latest_tag()
+                print("Merging from upstream tag: {0}".format(latest_tag))
                 subprocess.check_output('cd {0} && git merge --allow-unrelated-histories -X theirs --squash {1}'.format(
                 self.builddir, latest_tag), shell=True)
             actions.append(merge_from_upstream_tag)
@@ -56,12 +58,12 @@ class RemoteProject(BaseProject):
         :return: string The version number of the most up to date tag matching the current major version.
         """
         tags = subprocess.check_output('cd {0} && git tag'.format(self.builddir), shell=True).decode('utf-8').splitlines()
-        tags = [tag for tag in tags if tag.startswith(self.major_version)]
-        tags.sort(key=lambda s: [u for u in s.split('.')], reverse=True)
+        tags = [tag for tag in tags if tag.startswith(self.major_version) and 'beta' not in tag and 'alpha' not in tag]
+        tags.sort(key=lambda x: packaging.version.parse(x), reverse=True)
 
         tag = next(iter(tags), None)
 
         if tag == None:
-            raise Exception('No upstream tag found to merge from')
+            raise Exception('No upstream tag found to merge from.')
 
         return tag


### PR DESCRIPTION
 Now it excludes beta/alpha tags, and handles version segments greater than 9.