### PR TITLE
Add wp-postpass to cookie whitelist

### DIFF
--- a/templates/wordpress/files/.platform/routes.yaml
+++ b/templates/wordpress/files/.platform/routes.yaml
@@ -14,6 +14,7 @@
             - '/^wordpress_sec_/'
             - 'wordpress_test_cookie'
             - '/^wp-settings-/'
+            - '/^wp-postpass/'
 
 "https://www.{default}/":
     type: redirect


### PR DESCRIPTION
Cookies beginning with `wp-postpass_(HASH)` are [used by Wordpress to provide one-off page passwords](https://wordpress.org/support/article/using-password-protection/
). 

From user feedback in [#platformsh Slack 2020-01-10](https://platformsh.slack.com/archives/C0JHEUHQD/p1578633384485700?thread_ts=1578631656.485400&cid=C0JHEUHQD) 
Currently this cookie is stripped by the cache layer, and not making it back to the server, so this core wordpress functionality fails.
Maybe we should have it in our wordpress template.

The [nginx blog endorses that, with its example]( https://www.nginx.com/blog/9-tips-for-improving-wordpress-performance-with-nginx/) of how to tune caching for wordpress. Their example includes this cookie pattern as one not to cache.
Also recommended in [Wordpress docs for nginx](https://wordpress.org/support/article/nginx/#wp-super-cache-rules).