### PR TITLE
Fix create first admin link

### DIFF
--- a/templates/strapi/files/backend/build.sh
+++ b/templates/strapi/files/backend/build.sh
@@ -11,6 +11,7 @@ yarn add platformsh-config
 # Move the Platform.sh-specific configuration.
 rm config/environments/development/database.json && mv platformsh/database.js config/environments/development/database.js
 rm config/environments/development/server.json && mv platformsh/server.json config/environments/development/server.json
+rm public/index.html && mv platformsh/index.html public/index.html
 
 # Rebuild the admin panel.
 yarn build

--- a/templates/strapi/files/backend/platformsh/index.html
+++ b/templates/strapi/files/backend/platformsh/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <title>Welcome to your Strapi app</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap" rel="stylesheet" />
+    <style>
+      *{-webkit-box-sizing:border-box;text-decoration:none}body,html{margin:0;padding:0;font-size:62.5%;-webkit-font-smoothing:antialiased}body{font-size:1.3rem;font-family:Lato,Helvetica,Arial,Verdana,sans-serif;background:#fafafb;margin:0;padding:80px 0;color:#333740;line-height:1.8rem}strong{font-weight:700}.wrapper{width:684px;margin:auto}h1{text-align:center}h2{font-size:1.8rem;font-weight:700;margin-bottom:1px}.logo{height:40px;margin-bottom:74px}.informations{position:relative;overflow:hidden;display:flex;justify-content:space-between;width:100%;height:126px;margin-top:18px;padding:20px 30px;background:#fff;border-radius:2px;box-shadow:0 2px 4px 0 #e3e9f3}.informations:before{position:absolute;top:0;left:0;content:'';display:block;width:100%;height:2px;background:#007eff}.environment{display:inline-block;padding:0 10px;height:20px;margin-bottom:36px;background:#e6f0fb;border:1px solid #aed4fb;border-radius:2px;text-transform:uppercase;color:#007eff;font-size:1.2rem;font-weight:700;line-height:20px;letter-spacing:.05rem}.cta{display:inline-block;height:30px;padding:0 15px;margin-top:32px;border-radius:2px;color:#fff;font-weight:700;line-height:28px}.cta i{position:relative;display:inline-block;height:100%;vertical-align:middle;font-size:1rem;margin-right:20px}.cta i:before{position:absolute;top:8px}.cta-primary{background:#007eff}.cta-secondary{background:#6dbb1a}.text-align-right{text-align:right}.lets-started{position:relative;overflow:hidden;width:100%;height:144px;margin-top:18px;padding:20px 30px;background:#fff;border-radius:2px;box-shadow:0 2px 4px 0 #e3e9f3}.people-saying-hello{position:absolute;right:30px;bottom:-8px;width:113px;height:70px}.visible{opacity:1!important}.people-saying-hello img{position:absolute;max-width:100%;opacity:0;transition:opacity .2s ease-out}@media only screen and (max-width:768px){.wrapper{width:auto!important;margin:0 20px}.informations{flex-direction:column;height:auto}.environment{width:100%;text-align:center;margin-bottom:18px}.text-align-right{margin-top:18px;text-align:center}.cta{width:100%;text-align:center}.lets-started{height:auto}.people-saying-hello{display:none}}
+    </style>
+  </head>
+  <body lang="en">
+    <section class="wrapper">
+      <h1><img class="logo" src="https://strapi.io/assets/images/logo_login.png" /></h1>
+      <% if (isInitialised) { %>
+      <div class="informations">
+
+        <div>
+          <span class="environment"><%= strapi.config.environment %></span>
+          <p>
+            The server is running successfully (<strong>v<%= strapi.config.info.version %>)</strong>
+          </p>
+        </div>
+        <div class="text-align-right">
+          <p><%= serverTime %></p>
+          <a class="cta cta-primary" href="/admin" target="_blank" title="Click to open the administration" ><i class="fas fa-external-link-alt"></i>Open the administration</a>
+        </div>
+      </div>
+      <% } %>
+      <% if (!isInitialised) { %>
+
+        <div class="lets-started">
+          <h2>Let's get started!</h2>
+          <p>To discover the power provided by Strapi, you need to create an administrator.</p>
+          <a class="cta cta-secondary" href="/admin" target="_blank" title="Click to create the first administration" ><i class="fas fa-external-link-alt"></i>Create the first administrator</a>
+          <div class="people-saying-hello">
+            <img class="visible" src="https://strapi.io/assets/images/group_people_1.png" alt="People saying hello" />
+            <img src="https://strapi.io/assets/images/group_people_2.png" alt="People saying hello" />
+            <img src="https://strapi.io/assets/images/group_people_3.png" alt="People saying hello" />
+          </div>
+        </div>
+
+      <% } %>
+
+    </section>
+    <script>
+      var images=document.querySelectorAll('.people-saying-hello img');var nextIndex=0;setInterval(function(){var currentIndex=0;images.forEach(function(image,index){if(image.className==='visible'){currentIndex=index}});nextIndex=currentIndex+1;if(nextIndex===images.length){nextIndex=0}
+      images.forEach(function(image){image.classList.remove('visible')})
+      images[nextIndex].classList.add('visible')},1500)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Related to https://github.com/platformsh/template-builder/pull/179#issuecomment-575819764

Since [getPrimaryRoute](https://github.com/platformsh/config-reader-nodejs/pull/11/files) is not accessible during the build phase, I hardcoded the admin URL in the `index.html` file, which is replaced during the build phase.