### PR TITLE
Pin Flex-based projects to a specific PHP target version.

### DIFF
--- a/project/symfony.py
+++ b/project/symfony.py
@@ -30,8 +30,11 @@ class Symfony4(RemoteProject):
     @property
     def platformify(self):
         return super(Symfony4, self).platformify + [
-            'cd {0} && composer require platformsh/symfonyflex-bridge ^2.1 --ignore-platform-reqs'.format(
-                self.builddir)
+            # Symfony Flex now pins the lock files to a specific PHP version, so we have to in the platform version
+            # as well to avoid issues if the lock files are generated on a newer PHP version than the template uses.
+            # Keep this in sync with the template's PHP verison.
+            'cd {0} && composer config platform.php 7.3'.format(self.builddir),
+            'cd {0} && composer require platformsh/symfonyflex-bridge ^2.1 --ignore-platform-reqs'.format(self.builddir),
         ]
 
 class Symfony5(RemoteProject):
@@ -41,6 +44,9 @@ class Symfony5(RemoteProject):
     @property
     def platformify(self):
         return super(Symfony5, self).platformify + [
-            'cd {0} && composer require platformsh/symfonyflex-bridge ^2.1 --ignore-platform-reqs'.format(
-                self.builddir)
+            # Symfony Flex now pins the lock files to a specific PHP version, so we have to in the platform version
+            # as well to avoid issues if the lock files are generated on a newer PHP version than the template uses.
+            # Keep this in sync with the template's PHP verison.
+            'cd {0} && composer config platform.php 7.3'.format(self.builddir),
+            'cd {0} && composer require platformsh/symfonyflex-bridge ^2.1 --ignore-platform-reqs'.format(self.builddir),
         ]

--- a/templates/symfony4/ignore-env.patch
+++ b/templates/symfony4/ignore-env.patch
@@ -1,0 +1,10 @@
+diff --git a/.gitignore b/.gitignore
+index 136901b..2ad4cce 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -7,3 +7,5 @@
+ /var/
+ /vendor/
+ ###< symfony/framework-bundle ###
++
++.env

--- a/templates/symfony5/ignore-env.patch
+++ b/templates/symfony5/ignore-env.patch
@@ -1,0 +1,10 @@
+diff --git a/.gitignore b/.gitignore
+index 136901b..2ad4cce 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -7,3 +7,5 @@
+ /var/
+ /vendor/
+ ###< symfony/framework-bundle ###
++
++.env


### PR DESCRIPTION
Otherwise Flex tries to pin to PHP 7.4 on my computer, and then won't run on 7.3.  Because that makes sense.

cf: 
https://github.com/platformsh-templates/symfony4/pull/7
https://github.com/platformsh-templates/symfony5/pull/4