### PR TITLE
Update Eclipse MicroProfile versions and create test scope.

### DIFF
--- a/templates/micronaut/files/.platform.app.yaml
+++ b/templates/micronaut/files/.platform.app.yaml
@@ -14,7 +14,7 @@ disk: 1024
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
     build: |
-      mvn clean install -DskipTests
+      mvn clean install
 
 # The relationships of the application with services or other applications.
 #

--- a/templates/micronaut/files/pom.xml
+++ b/templates/micronaut/files/pom.xml
@@ -1,119 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>sh.platform.template</groupId>
-    <artifactId>micronaut</artifactId>
-    <version>1.0-SNAPSHOT</version>
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>sh.platform.template</groupId>
+   <artifactId>micronaut</artifactId>
+   <version>1.0-SNAPSHOT</version>
 
-    <properties>
-        <micronaut.version>1.2.6</micronaut.version>
-        <jdk.version>1.8</jdk.version>
-        <maven.compiler.target>${jdk.version}</maven.compiler.target>
-        <maven.compiler.source>${jdk.version}</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <exec.mainClass>sh.platform.template.Application</exec.mainClass>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-        <platform.sh.version>2.2.3</platform.sh.version>
-    </properties>
+   <properties>
+    <micronaut.version>1.2.10</micronaut.version>
+    <jdk.version>1.8</jdk.version>
+    <maven.compiler.target>${jdk.version}</maven.compiler.target>
+    <maven.compiler.source>${jdk.version}</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <exec.mainClass>sh.platform.template.Application</exec.mainClass>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+    <platform.sh.version>2.2.3</platform.sh.version>
+</properties>
 
-    <repositories>
-        <repository>
-            <id>jcenter.bintray.com</id>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
-    </repositories>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.micronaut</groupId>
-                <artifactId>micronaut-bom</artifactId>
-                <version>${micronaut.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+<repositories>
+    <repository>
+        <id>jcenter.bintray.com</id>
+        <url>https://jcenter.bintray.com</url>
+    </repository>
+</repositories>
+<dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-inject</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-validation</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-runtime</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-http-server-netty</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut</groupId>
-            <artifactId>micronaut-http-client</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>sh.platform</groupId>
-            <artifactId>config</artifactId>
-            <version>${platform.sh.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micronaut.test</groupId>
-            <artifactId>micronaut-test-junit5</artifactId>
-            <scope>test</scope>
+            <artifactId>micronaut-bom</artifactId>
+            <version>${micronaut.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <transformers>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${exec.mainClass}</mainClass>
-                                </transformer>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+</dependencyManagement>
+<dependencies>
+    <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-inject</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-validation</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-runtime</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-server-netty</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-client</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>sh.platform</groupId>
+        <artifactId>config</artifactId>
+        <version>${platform.sh.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.micronaut.test</groupId>
+        <artifactId>micronaut-test-junit5</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>shade</goal>
+                    </goals>
+                    <configuration>
+                        <transformers>
+                            <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <mainClass>${exec.mainClass}</mainClass>
+                            </transformer>
+                            <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                         </configuration>
                     </execution>
@@ -166,7 +166,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-parameters</arg>
@@ -181,11 +181,6 @@
                                 <groupId>io.micronaut</groupId>
                                 <artifactId>micronaut-validation</artifactId>
                                 <version>${micronaut.version}</version>
-                            </path>
-                            <path>
-                                <groupId>io.micronaut.configuration</groupId>
-                                <artifactId>micronaut-openapi</artifactId>
-                                <version>1.1.1</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
@@ -214,6 +209,13 @@
                             </configuration>
                         </execution>
                     </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>3.9</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/templates/micronaut/files/src/main/java/sh/platform/template/Application.java
+++ b/templates/micronaut/files/src/main/java/sh/platform/template/Application.java
@@ -2,40 +2,6 @@ package sh.platform.template;
 
 import io.micronaut.runtime.Micronaut;
 
-import io.swagger.v3.oas.annotations.*;
-import io.swagger.v3.oas.annotations.info.*;
-import io.swagger.v3.oas.annotations.tags.*;
-import io.swagger.v3.oas.annotations.servers.*;
-import io.swagger.v3.oas.annotations.security.*;
-
-@OpenAPIDefinition(
-        info = @Info(
-                title = "the title",
-                version = "0.0",
-                description = "My API",
-                license = @License(name = "Apache 2.0", url = "http://foo.bar"),
-                contact = @Contact(url = "http://gigantic-server.com", name = "Fred", email = "Fred@gigagantic-server.com")
-        ),
-        tags = {
-                @Tag(name = "Tag 1", description = "desc 1", externalDocs = @ExternalDocumentation(description = "docs desc")),
-                @Tag(name = "Tag 2", description = "desc 2", externalDocs = @ExternalDocumentation(description = "docs desc 2")),
-                @Tag(name = "Tag 3")
-        },
-        externalDocs = @ExternalDocumentation(description = "definition docs desc"),
-        security = {
-                @SecurityRequirement(name = "req 1", scopes = {"a", "b"}),
-                @SecurityRequirement(name = "req 2", scopes = {"b", "c"})
-        },
-        servers = {
-                @Server(
-                        description = "server 1",
-                        url = "http://foo",
-                        variables = {
-                                @ServerVariable(name = "var1", description = "var 1", defaultValue = "1", allowableValues = {"1", "2"}),
-                                @ServerVariable(name = "var2", description = "var 2", defaultValue = "1", allowableValues = {"1", "2"})
-                        })
-        }
-)
 public class Application {
 
     public static void main(String[] args) {

--- a/templates/micronaut/files/src/test/java/sh/platform/template/AppTest.java
+++ b/templates/micronaut/files/src/test/java/sh/platform/template/AppTest.java
@@ -1,0 +1,20 @@
+package sh.platform.template;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/templates/micronaut/files/src/test/resources/META-INF/beans.xml
+++ b/templates/micronaut/files/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/templates/microprofile-helidon/files/.platform.app.yaml
+++ b/templates/microprofile-helidon/files/.platform.app.yaml
@@ -13,7 +13,7 @@ disk: 1024
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
-    build: mvn -DskipTests clean package
+    build: mvn clean package
 
 # The relationships of the application with services or other applications.
 #

--- a/templates/microprofile-helidon/files/pom.xml
+++ b/templates/microprofile-helidon/files/pom.xml
@@ -64,7 +64,7 @@
                         <dependency>
                             <groupId>org.junit.platform</groupId>
                             <artifactId>junit-platform-surefire-provider</artifactId>
-                            <version>1.1.0</version>
+                            <version>1.3.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jandex</artifactId>
-                <version>2.1.1.Final</version>
+                <version>2.1.2.Final</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>
@@ -157,12 +157,12 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.0.1</version>
+                <version>5.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.0.1</version>
+                <version>5.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -172,7 +172,7 @@
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-binding</artifactId>
-                <version>2.29</version>
+                <version>2.30</version>
             </dependency>
             <dependency>
                 <groupId>sh.platform</groupId>

--- a/templates/microprofile-helidon/files/pom.xml
+++ b/templates/microprofile-helidon/files/pom.xml
@@ -59,14 +59,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.junit.platform</groupId>
-                            <artifactId>junit-platform-surefire-provider</artifactId>
-                            <version>1.3.2</version>
-                        </dependency>
-                    </dependencies>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/templates/microprofile-kumuluzee/files/.platform.app.yaml
+++ b/templates/microprofile-kumuluzee/files/.platform.app.yaml
@@ -13,7 +13,7 @@ disk: 1024
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
-    build: mvn -DskipTests clean package kumuluzee:repackage
+    build: mvn clean package kumuluzee:repackage
 
 mounts:
     '/app':

--- a/templates/microprofile-kumuluzee/files/pom.xml
+++ b/templates/microprofile-kumuluzee/files/pom.xml
@@ -1,55 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>sh.platform.template</groupId>
-    <artifactId>microprofile-kumuluzee</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>sh.platform.template</groupId>
+   <artifactId>microprofile-kumuluzee</artifactId>
+   <version>1.0.0-SNAPSHOT</version>
+   <packaging>jar</packaging>
 
-    <properties>
-        <version.microprofile>2.2</version.microprofile>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
-        <kumuluzee.version>3.5.0</kumuluzee.version>
-        <platform.sh.version>2.2.3</platform.sh.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+   <properties>
+    <version.microprofile>2.2</version.microprofile>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <junit.version>5.6.0</junit.version>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+    <kumuluzee.version>3.6.1</kumuluzee.version>
+    <platform.sh.version>2.2.3</platform.sh.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+</properties>
 
+<dependencies>
+    <dependency>
+        <groupId>com.kumuluz.ee</groupId>
+        <artifactId>kumuluzee-microProfile-1.0</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>sh.platform</groupId>
+        <artifactId>config</artifactId>
+        <version>${platform.sh.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+
+<build>
+    <finalName>microprofile</finalName>
+    <plugins>
+        <plugin>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-maven-plugin</artifactId>
+            <version>${kumuluzee.version}</version>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven.surefire.plugin.version}</version>
+        </plugin>
+    </plugins>
+</build>
+
+<dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.kumuluz.ee</groupId>
-            <artifactId>kumuluzee-microProfile-1.0</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>sh.platform</groupId>
-            <artifactId>config</artifactId>
-            <version>${platform.sh.version}</version>
+            <artifactId>kumuluzee-bom</artifactId>
+            <version>${kumuluzee.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <finalName>microprofile</finalName>
-        <plugins>
-            <plugin>
-                <groupId>com.kumuluz.ee</groupId>
-                <artifactId>kumuluzee-maven-plugin</artifactId>
-                <version>${kumuluzee.version}</version>
-            </plugin>
-        </plugins>
-    </build>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.kumuluz.ee</groupId>
-                <artifactId>kumuluzee-bom</artifactId>
-                <version>${kumuluzee.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+</dependencyManagement>
 
 </project>

--- a/templates/microprofile-kumuluzee/files/src/test/java/sh/platform/template/AppTest.java
+++ b/templates/microprofile-kumuluzee/files/src/test/java/sh/platform/template/AppTest.java
@@ -1,0 +1,20 @@
+package sh.platform.template;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/templates/microprofile-kumuluzee/files/src/test/resources/META-INF/beans.xml
+++ b/templates/microprofile-kumuluzee/files/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/templates/microprofile-openliberty/files/pom.xml
+++ b/templates/microprofile-openliberty/files/pom.xml
@@ -1,77 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+   <modelVersion>4.0.0</modelVersion>
 
-    <groupId>sh.platform.template</groupId>
-    <artifactId>microprofile-liberty</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>war</packaging>
+   <groupId>sh.platform.template</groupId>
+   <artifactId>microprofile-liberty</artifactId>
+   <version>1.0-SNAPSHOT</version>
+   <packaging>war</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <app.name>LibertyProject</app.name>
-        <testServerHttpPort>9080</testServerHttpPort>
-        <testServerHttpsPort>9080</testServerHttpsPort>
-        <package.file>${project.build.directory}/${app.name}.zip</package.file>
-        <packaging.type>usr</packaging.type>
-        <skipTests>false</skipTests>
-        <platform.sh.version>2.2.3</platform.sh.version>
-    </properties>
+   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <app.name>LibertyProject</app.name>
+    <testServerHttpPort>9080</testServerHttpPort>
+    <testServerHttpsPort>9080</testServerHttpsPort>
+    <package.file>${project.build.directory}/${app.name}.zip</package.file>
+    <packaging.type>usr</packaging.type>
+    <skipTests>false</skipTests>
+    <platform.sh.version>2.2.3</platform.sh.version>
+    <junit.version>5.6.0</junit.version>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+</properties>
 
-    <parent>
-        <groupId>io.openliberty.tools</groupId>
-        <artifactId>liberty-maven-app-parent</artifactId>
-        <version>3.0-M2</version>
-    </parent>
+<parent>
+    <groupId>io.openliberty.tools</groupId>
+    <artifactId>liberty-maven-app-parent</artifactId>
+    <version>3.0-M2</version>
+</parent>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>3.1</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>sh.platform</groupId>
-            <artifactId>config</artifactId>
-            <version>${platform.sh.version}</version>
-        </dependency>
-        <!-- dependencies for tests -->
-    </dependencies>
+<dependencies>
+    <dependency>
+        <groupId>org.eclipse.microprofile</groupId>
+        <artifactId>microprofile</artifactId>
+        <version>3.2</version>
+        <type>pom</type>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>sh.platform</groupId>
+        <artifactId>config</artifactId>
+        <version>${platform.sh.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
 
-    <build>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.3</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>io.openliberty.tools</groupId>
-                <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.0-M2</version>
-                <configuration>
-                    <!-- set install-apps goal parameters -->
-                    <looseApplication>true</looseApplication>
-                    <installAppPackages>project</installAppPackages>
-                    <packageFile>${project.build.directory}/${project.build.finalName}.jar</packageFile>
-                    <include>runnable</include>
-                    <bootstrapProperties>
-                        <default.http.port>${testServerHttpPort}</default.http.port>
-                        <default.https.port>${testServerHttpsPort}</default.https.port>
-                    </bootstrapProperties>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+<build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>3.2.3</version>
+            <configuration>
+                <failOnMissingWebXml>false</failOnMissingWebXml>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>io.openliberty.tools</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+            <version>3.0-M2</version>
+            <configuration>
+                <!-- set install-apps goal parameters -->
+                <looseApplication>true</looseApplication>
+                <installAppPackages>project</installAppPackages>
+                <packageFile>${project.build.directory}/${project.build.finalName}.jar</packageFile>
+                <include>runnable</include>
+                <bootstrapProperties>
+                    <default.http.port>${testServerHttpPort}</default.http.port>
+                    <default.https.port>${testServerHttpsPort}</default.https.port>
+                </bootstrapProperties>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven.surefire.plugin.version}</version>
+        </plugin>
+    </plugins>
+</build>
 </project>

--- a/templates/microprofile-openliberty/files/src/test/java/sh/platform/template/AppTest.java
+++ b/templates/microprofile-openliberty/files/src/test/java/sh/platform/template/AppTest.java
@@ -1,0 +1,20 @@
+package sh.platform.template;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/templates/microprofile-openliberty/files/src/test/resources/META-INF/beans.xml
+++ b/templates/microprofile-openliberty/files/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/templates/microprofile-payara/files/.platform.app.yaml
+++ b/templates/microprofile-payara/files/.platform.app.yaml
@@ -13,7 +13,7 @@ disk: 1024
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
-    build:  mvn -DskipTests clean package payara-micro:bundle
+    build:  mvn clean package payara-micro:bundle
 
 
 # The relationships of the application with services or other applications.

--- a/templates/microprofile-thorntail/files/.platform.app.yaml
+++ b/templates/microprofile-thorntail/files/.platform.app.yaml
@@ -13,7 +13,7 @@ disk: 1024
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
-    build:  mvn -DskipTests clean package thorntail:package
+    build:  mvn clean package thorntail:package
 
 # The relationships of the application with services or other applications.
 #

--- a/templates/microprofile-thorntail/files/pom.xml
+++ b/templates/microprofile-thorntail/files/pom.xml
@@ -1,53 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>sh.platform.template</groupId>
-    <artifactId>microprofile-thorntail</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>war</packaging>
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+ <modelVersion>4.0.0</modelVersion>
+ <groupId>sh.platform.template</groupId>
+ <artifactId>microprofile-thorntail</artifactId>
+ <version>1.0.0-SNAPSHOT</version>
+ <packaging>war</packaging>
 
-    <properties>
-        <version.thorntail>2.6.0.Final</version.thorntail>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
-        <platform.sh.version>2.2.3</platform.sh.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.thorntail</groupId>
-                <artifactId>bom-all</artifactId>
-                <version>${version.thorntail}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+ <properties>
+    <version.thorntail>2.6.0.Final</version.thorntail>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+    <platform.sh.version>2.2.3</platform.sh.version>
+    <junit.version>5.6.0</junit.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+</properties>
+<dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.thorntail</groupId>
-            <artifactId>microprofile</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>sh.platform</groupId>
-            <artifactId>config</artifactId>
-            <version>${platform.sh.version}</version>
+            <artifactId>bom-all</artifactId>
+            <version>${version.thorntail}</version>
+            <scope>import</scope>
+            <type>pom</type>
         </dependency>
     </dependencies>
+</dependencyManagement>
 
-    <build>
-        <finalName>microprofile</finalName>
-        <plugins>
-            <plugin>
-                <groupId>io.thorntail</groupId>
-                <artifactId>thorntail-maven-plugin</artifactId>
-                <version>${version.thorntail}</version>
-            </plugin>
-        </plugins>
-    </build>
+<dependencies>
+    <dependency>
+        <groupId>io.thorntail</groupId>
+        <artifactId>microprofile</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>sh.platform</groupId>
+        <artifactId>config</artifactId>
+        <version>${platform.sh.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+
+<build>
+    <finalName>microprofile</finalName>
+    <plugins>
+        <plugin>
+            <groupId>io.thorntail</groupId>
+            <artifactId>thorntail-maven-plugin</artifactId>
+            <version>${version.thorntail}</version>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven.surefire.plugin.version}</version>
+        </plugin>
+    </plugins>
+</build>
 
 </project>

--- a/templates/microprofile-thorntail/files/src/test/java/sh/platform/template/AppTest.java
+++ b/templates/microprofile-thorntail/files/src/test/java/sh/platform/template/AppTest.java
@@ -1,0 +1,20 @@
+package sh.platform.template;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/templates/microprofile-thorntail/files/src/test/resources/META-INF/beans.xml
+++ b/templates/microprofile-thorntail/files/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/templates/microprofile-tomee/files/.platform.app.yaml
+++ b/templates/microprofile-tomee/files/.platform.app.yaml
@@ -13,7 +13,7 @@ disk: 1024
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
-    build: mvn -Dhttp.port=8888 -DskipTests clean install tomee:exec
+    build: mvn -Dhttp.port=8888 clean install tomee:exec
 
 mounts:
 

--- a/templates/microprofile-tomee/files/pom.xml
+++ b/templates/microprofile-tomee/files/pom.xml
@@ -1,62 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>sh.platform.template</groupId>
-    <artifactId>microprofile-tomee</artifactId>
-    <name>CloudEE Duke</name>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>war</packaging>
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+ <modelVersion>4.0.0</modelVersion>
+ <groupId>sh.platform.template</groupId>
+ <artifactId>microprofile-tomee</artifactId>
+ <name>CloudEE Duke</name>
+ <version>1.0.0-SNAPSHOT</version>
+ <packaging>war</packaging>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <failOnMissingWebXml>false</failOnMissingWebXml>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.microprofile>2.2</version.microprofile>
-        <tomee.version>8.0.0-M3</tomee.version>
-        <version.payara.micro>5.191</version.payara.micro>
-        <platform.sh.version>2.2.2</platform.sh.version>
-        <http.port>8888</http.port>
-    </properties>
+ <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <version.microprofile>2.2</version.microprofile>
+    <tomee.version>8.0.0-M3</tomee.version>
+    <platform.sh.version>2.2.3</platform.sh.version>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+    <junit.version>5.6.0</junit.version>
+    <http.port>8888</http.port>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+</properties>
 
-    <build>
-        <finalName>ROOT</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.2</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                    <packagingExcludes>pom.xml</packagingExcludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.tomee.maven</groupId>
-                <artifactId>tomee-maven-plugin</artifactId>
-                <version>${tomee.version}</version>
-                <configuration>
-                    <tomeeClassifier>microprofile</tomeeClassifier>
-                    <tomeeHttpPort>${http.port}</tomeeHttpPort>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+<build>
+    <finalName>ROOT</finalName>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>3.2.2</version>
+            <configuration>
+                <failOnMissingWebXml>false</failOnMissingWebXml>
+                <packagingExcludes>pom.xml</packagingExcludes>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.tomee.maven</groupId>
+            <artifactId>tomee-maven-plugin</artifactId>
+            <version>${tomee.version}</version>
+            <configuration>
+                <tomeeClassifier>microprofile</tomeeClassifier>
+                <tomeeHttpPort>${http.port}</tomeeHttpPort>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven.surefire.plugin.version}</version>
+        </plugin>
+    </plugins>
+</build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>${version.microprofile}</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>sh.platform</groupId>
-            <artifactId>config</artifactId>
-            <version>${platform.sh.version}</version>
-        </dependency>
-    </dependencies>
+<dependencies>
+    <dependency>
+        <groupId>org.eclipse.microprofile</groupId>
+        <artifactId>microprofile</artifactId>
+        <version>${version.microprofile}</version>
+        <type>pom</type>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>sh.platform</groupId>
+        <artifactId>config</artifactId>
+        <version>${platform.sh.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
 
 </project>

--- a/templates/microprofile-tomee/files/src/test/java/sh/platform/template/AppTest.java
+++ b/templates/microprofile-tomee/files/src/test/java/sh/platform/template/AppTest.java
@@ -1,0 +1,20 @@
+package sh.platform.template;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/templates/microprofile-tomee/files/src/test/resources/META-INF/beans.xml
+++ b/templates/microprofile-tomee/files/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
This PR has the goal of updating the Eclipse MicroProfile version into the MicroProfile implementations. Therefore, it will remove deprecated annotations and create a test context and update the JUnit to JUnit Jupiter 5.6.0.

# Changes 

* [Updates the test unit framework to Junit Jupiter 5.6.0](https://junit.org/junit5/docs/snapshot/release-notes/#release-notes-5.6.0)
* Updates Eclipse MicroProfile Libraries
* Removes deprecated annotations in Micronauts
* Creates test scope to all Eclipse Microprofile templates


## Referentes
- https://github.com/platformsh-templates/microprofile-payara/pull/6
- https://github.com/platformsh-templates/microprofile-tomee/pull/3
- https://github.com/platformsh-templates/microprofile-kumuluzee/pull/4
- https://github.com/platformsh-templates/microprofile-helidon/pull/5
- https://github.com/platformsh-templates/microprofile-thorntail/pull/5
- https://github.com/platformsh-templates/microprofile-openliberty/pull/5
- https://github.com/platformsh-templates/micronaut/pull/4
