### PR TITLE
Magento 2.3.4 upgrade

### DIFF
--- a/project/remote.py
+++ b/project/remote.py
@@ -31,7 +31,9 @@ class RemoteProject(BaseProject):
             'cd {0} && git checkout master'.format(self.builddir),
             'cd {0} && git fetch --all --depth=2'.format(self.builddir),
             'cd {0} && git fetch --all --tags'.format(self.builddir),
-            'cd {0} && (find . ! -path . | grep -v ".git" | xargs rm -rf)'.format(self.builddir),
+            # Remove working directory files when updating from upstream, so that deletions get picked up.
+            # The @ directive means "match if exactly one of these patterns matches". There's then two patterns,
+            'cd {0} &&  (find . -maxdepth 1 -not \( -path ./.git -o -path . \) -exec rm -rf {{}} \;)'.format(self.builddir),
         ]
 
         if hasattr(self, 'major_version'):

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -13,6 +13,7 @@ type: php:7.2
 runtime:
     extensions:
     - xsl
+    - sodium
 
 # Configuration of the build of this application.
 build:

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -95,3 +95,11 @@ web:
             rules:
                 ^/static/version\d+/(?<resource>.*)$:
                     passthru: "/static/$resource"
+
+workers:
+    queue:
+        size: S
+        disk: 128
+        commands:
+            start: |
+                bin/magento queue:consumers:start --single-thread --max-messages=10000


### PR DESCRIPTION
Includes suggested fixes for outstanding issues, but those seem to not resolve those issues.  Still, we can iterate from here, and this includes a bug fix for the wipe-before-merge routine.