### PR TITLE
Fixes baseURL and protocol.

### DIFF
--- a/templates/gatsby-wordpress/files/gatsby/gatsby-config.js
+++ b/templates/gatsby-wordpress/files/gatsby/gatsby-config.js
@@ -19,9 +19,9 @@ module.exports = {
          * The base URL of the WordPress site without the trailingslash and the protocol. This is required.
          * Example : 'demo.wp-api.org' or 'www.example-site.com'
          */
-        baseUrl: config.credentials("wordpress").url.split("/")[2],
+        baseUrl: config.credentials("wordpress")["host"],
         // The protocol. This can be http or https.
-        protocol: `https`,
+        protocol: `http`,
         // Indicates whether the site is hosted on wordpress.com.
         // If false, then the assumption is made that the site is self hosted.
         // If true, then the plugin will source its content on wordpress.com using the JSON REST API V2.


### PR DESCRIPTION
Backend was not actually being pulled from previous configuration, but wasn't failing either because it was previously setup using the route rather than the relationship. 

This fixes that first install experience to do it the right way.

https://github.com/platformsh-templates/gatsby-wordpress/pull/2