### PR TITLE
Updates strapi admin link with new index.html patch file.

### DIFF
--- a/templates/strapi/files/backend/build.sh
+++ b/templates/strapi/files/backend/build.sh
@@ -13,7 +13,7 @@ rm config/environments/development/database.json && mv platformsh/database.js co
 rm config/environments/development/server.json && mv platformsh/server.json config/environments/development/server.json
 
 # Move index.html with working admin link.
-rm public/index.html && mv platformsh/index.html public/index.html
+mv platformsh/index.html public/index.html
 
 # Rebuild the admin panel.
 yarn build

--- a/templates/strapi/files/backend/platformsh/index.html
+++ b/templates/strapi/files/backend/platformsh/index.html
@@ -1,3 +1,4 @@
+
 <!doctype html>
 <html>
   <head>
@@ -5,7 +6,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Welcome to your Strapi app</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="robots" content="noindex">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap" rel="stylesheet" />
@@ -16,27 +16,11 @@
   <body lang="en">
     <section class="wrapper">
       <h1><img class="logo" src="https://strapi.io/assets/images/logo_login.png" /></h1>
-      <% if (isInitialised) { %>
-      <div class="informations">
-
-        <div>
-          <span class="environment"><%= strapi.config.environment %></span>
-          <p>
-            The server is running successfully (<strong>v<%= strapi.config.info.version %>)</strong>
-          </p>
-        </div>
-        <div class="text-align-right">
-          <p><%= serverTime %></p>
-          <a class="cta cta-primary" href="/admin" target="_blank" title="Click to open the administration" ><i class="fas fa-external-link-alt"></i>Open the administration</a>
-        </div>
-      </div>
-      <% } %>
-      <% if (!isInitialised) { %>
 
         <div class="lets-started">
           <h2>Let's get started!</h2>
           <p>To discover the power provided by Strapi, you need to create an administrator.</p>
-          <a class="cta cta-secondary" href="/admin" target="_blank" title="Click to create the first administration" ><i class="fas fa-external-link-alt"></i>Create the first administrator</a>
+          <a class="cta cta-secondary" href="/admin" title="Click to create the first administration" ><i class="fas fa-external-link-alt"></i>Create the first administrator</a>
           <div class="people-saying-hello">
             <img class="visible" src="https://strapi.io/assets/images/group_people_1.png" alt="People saying hello" />
             <img src="https://strapi.io/assets/images/group_people_2.png" alt="People saying hello" />
@@ -44,13 +28,14 @@
           </div>
         </div>
 
-      <% } %>
-
     </section>
-    <script>
-      var images=document.querySelectorAll('.people-saying-hello img');var nextIndex=0;setInterval(function(){var currentIndex=0;images.forEach(function(image,index){if(image.className==='visible'){currentIndex=index}});nextIndex=currentIndex+1;if(nextIndex===images.length){nextIndex=0}
-      images.forEach(function(image){image.classList.remove('visible')})
-      images[nextIndex].classList.add('visible')},1500)
-    </script>
+
+
+      <script>
+        var images=document.querySelectorAll('.people-saying-hello img');var nextIndex=0;setInterval(function(){var currentIndex=0;images.forEach(function(image,index){if(image.className==='visible'){currentIndex=index}});nextIndex=currentIndex+1;if(nextIndex===images.length){nextIndex=0}
+        images.forEach(function(image){image.classList.remove('visible')})
+        images[nextIndex].classList.add('visible')},1500)
+      </script>
+
   </body>
 </html>


### PR DESCRIPTION
We had a comment in #platformsh that the first `/admin` link button was directing to `localhost` again. This is the updated `index.html` file to fix that  from strapi, which we're already using in `gatsby-strapi`.

https://github.com/platformsh-templates/strapi/pull/2