### PR TITLE
Adds an instruction to remove the open liberty workspace before start.

### DIFF
--- a/templates/microprofile-openliberty/files/.platform.app.yaml
+++ b/templates/microprofile-openliberty/files/.platform.app.yaml
@@ -14,6 +14,7 @@ disk: 1024
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
     build: |
+       rm -rf wlpExtract
        mvn clean package
 
 mounts:


### PR DESCRIPTION
https://github.com/platformsh-templates/microprofile-openliberty/pull/8