### PR TITLE
Symfony 3 not 4.

### DIFF
--- a/project/symfony.py
+++ b/project/symfony.py
@@ -18,7 +18,7 @@ class Symfony3(RemoteProject):
             # 2.x gets installed.  That's explicitly not compatible with Symfony < 5, however.  Instead, force
             # an extra dependency on Monolog 1 to sidestep that issue.  It has to be done in a single install
             # step to avoid issues with Symfony's install script failing if either of these packages are missing.
-            'cd {0} && composer require platformsh/config-reader monolog/monolog ~1.22 --ignore-platform-reqs && composer update --no-plugins'.format(
+            'cd {0} && composer require platformsh/config-reader monolog/monolog ~1.22 --ignore-platform-reqs && composer update'.format(
                 self.builddir),
         ]
 

--- a/project/symfony.py
+++ b/project/symfony.py
@@ -18,10 +18,9 @@ class Symfony3(RemoteProject):
             # 2.x gets installed.  That's explicitly not compatible with Symfony < 5, however.  Instead, force
             # an extra dependency on Monolog 1 to sidestep that issue.  It has to be done in a single install
             # step to avoid issues with Symfony's install script failing if either of these packages are missing.
-            'cd {0} && composer require platformsh/config-reader monolog/monolog ~1.22 --ignore-platform-reqs'.format(
+            'cd {0} && composer require platformsh/config-reader monolog/monolog ~1.22 --ignore-platform-reqs && composer update --no-plugins'.format(
                 self.builddir),
         ]
-
 
 class Symfony4(RemoteProject):
     major_version = 'v4'

--- a/templates/symfony3/.platform.template.yaml
+++ b/templates/symfony3/.platform.template.yaml
@@ -4,7 +4,7 @@ info:
   id: platformsh/symfony3
   name: Symfony 3
   description: |
-      <p>This template provides a basic Symfony 4 skeleton.  It comes pre-configured to use a MariaDB database via a custom config file.  It is intended for you to use as a starting point and modify for your own needs.</p>
+      <p>This template provides a basic Symfony 3 skeleton.  It comes pre-configured to use a MariaDB database via a custom config file.  It is intended for you to use as a starting point and modify for your own needs.</p>
       <p>It is configured for Production mode by default, so the usual Symfony "welcome" page will not appear.  Instead, you will see a 404 page after the site first deploys, which is normal.  You may switch it into dev mode via `.platform.app.yaml` if desired.</p>
       <p>Symfony is a high-performance loosely-coupled PHP web development framework.</p>
       <p>New projects should be built using Symfony 5, but this project is a reference for existing migrating sites.  Version 3 is the LTS support version.</p>

--- a/templates/symfony3/files/README.md
+++ b/templates/symfony3/files/README.md
@@ -6,7 +6,7 @@
 </a>
 </p>
 
-This template provides a basic Symfony 4 skeleton.  It comes pre-configured to use a MariaDB database via a custom config file.  It is intended for you to use as a starting point and modify for your own needs.
+This template provides a basic Symfony 3 skeleton.  It comes pre-configured to use a MariaDB database via a custom config file.  It is intended for you to use as a starting point and modify for your own needs.
 
 It is configured for Production mode by default, so the usual Symfony "welcome" page will not appear.  Instead, you will see a 404 page after the site first deploys, which is normal.  You may switch it into dev mode via `.platform.app.yaml` if desired.
 


### PR DESCRIPTION
https://github.com/platformsh-templates/symfony3/pull/9

Adds  `composer update --no-plugins`, due to this message

```
The "ocramius/package-versions" plugin was skipped because it requires a Plugin API version ("^2.0.0") that does not match your Composer installation ("1.1.0"). You may need to run composer update with the "--no-plugins" option.
```

It is the last command in `platformify`, which then returns

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downgrading ocramius/package-versions (1.10.0 => 1.9.0): Loading from cache
```

Before this change, Symfony fails on Platform.sh:

```
 Found 1 new commit
 
 Building application 'app' (runtime type: php:7.4, tree: 8a2cd25)
   Generating runtime configuration.
   
   Moving the application to the output directory
   Prewarming composer cache.
   
   Found a `composer.json`, installing dependencies.
     W: Loading composer repositories with package information
     W: Installing dependencies (including require-dev) from lock file
     W: Your requirements could not be resolved to an installable set of packages.
     W: 
     W:   Problem 1
     W:     - Installation request for ocramius/package-versions 1.10.0 -> satisfiable by ocramius/package-versions[1.10.0].
     W:     - ocramius/package-versions 1.10.0 requires composer-plugin-api ^2.0.0 -> no matching package found.
     W:   Problem 2
     W:     - ocramius/package-versions 1.10.0 requires composer-plugin-api ^2.0.0 -> no matching package found.
     W:     - doctrine/orm v2.7.3 requires ocramius/package-versions ^1.2 -> satisfiable by ocramius/package-versions[1.10.0].
     W:     - Installation request for doctrine/orm v2.7.3 -> satisfiable by doctrine/orm[v2.7.3].
     W: 
     W: Potential causes:
     W:  - A typo in the package name
     W:  - The package is not available in a stable-enough version according to your minimum-stability setting
     W:    see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
     W:  - It's a private package and you forgot to add a custom repository to find it
     W: 
     W: Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
   
   E: Error building project: `composer` could not be run.
 
 E: Error: Unable to build application, aborting.
 
```