### PR TITLE
Add good Lando defaults for the TYPO3 template

### DIFF
--- a/templates/typo3/files/.lando.upstream.yml
+++ b/templates/typo3/files/.lando.upstream.yml
@@ -1,0 +1,18 @@
+# This file sets some good defaults for local development using this Platform.sh
+# template with Lando.
+#
+# Note that you should not edit this file so it can continue to receive upstream
+# updates. If you wish to change the values below then override them in your
+# normal .lando.yml.
+
+# These both allow you to test this template without needing a site on Platform.sh
+# However you will want to replace them in your .lando.yml
+name: platformsh-typo3
+recipe: platformsh
+
+# These are tools that are commonly used during development for this template.
+tooling:
+  typo3:
+    service: app
+  typo3cms:
+    service: app


### PR DESCRIPTION
@Crell and @pirog to review. Specifically need to discuss:

* Any TYPO3 envvars we need to set that are best for the localdevs?
* `lando rebuild` fails because the `build` hook tries to reinstall TYPO3 even though it's already installed? Should we make the install conditional?

This should be considered a draft for now.  