### PR TITLE
Remove --skip-install option to generate the lock

### DIFF
--- a/project/rails.py
+++ b/project/rails.py
@@ -16,7 +16,7 @@ class Rails(BaseProject):
     @property
     def platformify(self):
         return super(Rails, self).platformify + [
-            'cd {0} && bundle add unicorn pg platform_sh_rails --group "production" --skip-install'.format(self.builddir),
+            'cd {0} && bundle add unicorn pg platform_sh_rails --group "production"'.format(self.builddir),
             'cd {0} && echo config/database.yml >> .gitignore'.format(self.builddir),
             'cd {0} && mv config/database.yml config/database.yml.example'.format(self.builddir),
             # Remove the Rails Ruby version lock file, as it's not needed.


### PR DESCRIPTION
We plan to use deployment flag on our template as a result
the Gemfile.lock need to be valid before deploy and currently
we are skipping it.

        W: You are trying to install in deployment mode after changing
        W: your Gemfile. Run `bundle install` elsewhere and add the
        W: updated Gemfile.lock to version control.
        W:
        W: If this is a development machine, remove the /app/Gemfile freeze
        W: by running `bundle config unset deployment`.
        W:
        W: The dependencies in your gemfile changed
        W:
        W: You have added to the Gemfile:
        W: * unicorn (~> 5.7)
        W: * pg (~> 1.2)
        W: * platform_sh_rails (~> 0.1.12)
        W:
        W: You have deleted from the Gemfile:
        W: * pg
        W: * platform_sh_rails
        W: * unicorn