### PR TITLE
mount media files, sharing import files

### DIFF
--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -64,6 +64,15 @@ mounts:
     "upgrades":
         source: local
         source_path: "upgrades"
+    # For media files
+    "public/media":
+        source: local
+        source_path: "public/media"
+    # Sharing job files
+    "var/file_storage/jobs":
+        source: service
+        service: files
+        source_path: "var/file_storage/jobs"
 
 dependencies:
     nodejs:

--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -71,7 +71,7 @@ mounts:
     # Sharing job files
     "var/file_storage/jobs":
         source: service
-        service: files
+        service: jobs
         source_path: "var/file_storage/jobs"
 
 dependencies:

--- a/templates/akeneo/files/.platform/services.yaml
+++ b/templates/akeneo/files/.platform/services.yaml
@@ -8,3 +8,6 @@ db:
 search:
     type: elasticsearch:7.7
     disk: 512
+jobs:
+    type: network-storage:1.0
+    disk: 128


### PR DESCRIPTION
Current Akeneo template doesn't mount media files, so you can not view uploaded images. Additionally if you try to import something with Akeneo importers it will not work because your uploaded files are located in app, but importer daemon works in app-queue, I added another configuration to share job files between app & app-queue with network storage.