### PR TITLE
Switch to Composer 2 for most PHP projects.

### DIFF
--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -7,8 +7,6 @@ name: app
 type: php:7.3
 
 dependencies:
-    php:
-        composer/composer: '^2'
     nodejs:
         yarn: "*"
 

--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -6,6 +6,12 @@ name: app
 # The language and version to use to run the application.
 type: php:7.3
 
+dependencies:
+    php:
+        composer/composer: '^2'
+    nodejs:
+        yarn: "*"
+
 # Enable non-default extensions required by Akeneo
 runtime:
     extensions:
@@ -73,10 +79,6 @@ mounts:
         source: service
         service: jobs
         source_path: "var/file_storage/jobs"
-
-dependencies:
-    nodejs:
-        yarn: "*"
 
 hooks:
     # We run the build hook before your application has been packaged.

--- a/templates/drupal8-multisite/files/.platform.app.yaml
+++ b/templates/drupal8-multisite/files/.platform.app.yaml
@@ -9,6 +9,10 @@ name: 'app'
 # The runtime the application uses.
 type: 'php:7.4'
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 runtime:
     # Enable the redis extension so Drupal can communicate with the Redis cache.
     extensions:

--- a/templates/drupal8-opigno/files/.platform.app.yaml
+++ b/templates/drupal8-opigno/files/.platform.app.yaml
@@ -9,6 +9,10 @@ name: 'app'
 # The runtime the application uses.
 type: 'php:7.3'
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 runtime:
     # Enable the redis extension so Drupal can communicate with the Redis cache.
     extensions:

--- a/templates/drupal8/files/.platform.app.yaml
+++ b/templates/drupal8/files/.platform.app.yaml
@@ -9,6 +9,10 @@ name: 'app'
 # The runtime the application uses.
 type: 'php:7.4'
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 runtime:
     # Enable the redis extension so Drupal can communicate with the Redis cache.
     extensions:

--- a/templates/drupal9/files/.platform.app.yaml
+++ b/templates/drupal9/files/.platform.app.yaml
@@ -9,6 +9,10 @@ name: 'app'
 # The runtime the application uses.
 type: 'php:7.4'
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 runtime:
     # Enable the redis extension so Drupal can communicate with the Redis cache.
     extensions:

--- a/templates/gatsby-drupal/files/drupal/.platform.app.yaml
+++ b/templates/gatsby-drupal/files/drupal/.platform.app.yaml
@@ -9,10 +9,6 @@ name: 'drupal'
 # The runtime the application uses.
 type: 'php:7.4'
 
-dependencies:
-  php:
-    composer/composer: '^2'
-
 # The relationships of the application with services or other applications.
 #
 # The left-hand side is the name of the relationship as it will be exposed

--- a/templates/gatsby-drupal/files/drupal/.platform.app.yaml
+++ b/templates/gatsby-drupal/files/drupal/.platform.app.yaml
@@ -9,6 +9,10 @@ name: 'drupal'
 # The runtime the application uses.
 type: 'php:7.4'
 
+dependencies:
+  php:
+    composer/composer: '^2'
+
 # The relationships of the application with services or other applications.
 #
 # The left-hand side is the name of the relationship as it will be exposed

--- a/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
+++ b/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
@@ -11,6 +11,11 @@ type: "php:7.4"
 build:
     flavor: composer
 
+dependencies:
+    php:
+        composer/composer: '^2'
+        wp-cli/wp-cli: "^2.2.0"
+
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
@@ -51,9 +56,6 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 1280
-dependencies:
-    php:
-        wp-cli/wp-cli: "^2.2.0"
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
+++ b/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
@@ -13,7 +13,6 @@ build:
 
 dependencies:
     php:
-        composer/composer: '^2'
         wp-cli/wp-cli: "^2.2.0"
 
 # The relationships of the application with services or other applications.

--- a/templates/laravel/files/.platform.app.yaml
+++ b/templates/laravel/files/.platform.app.yaml
@@ -7,6 +7,10 @@ name: app
 # The type of the application to build.
 type: php:7.4
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 runtime:
     extensions:
         - redis

--- a/templates/sculpin/files/.platform.app.yaml
+++ b/templates/sculpin/files/.platform.app.yaml
@@ -9,6 +9,10 @@ name: app
 # The runtime the application uses.
 type: "php:7.4"
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
     build: |

--- a/templates/symfony4/files/.platform.app.yaml
+++ b/templates/symfony4/files/.platform.app.yaml
@@ -6,8 +6,13 @@ name: app
 
 # The type of the application to build.
 type: php:7.4
+
 build:
     flavor: composer
+
+dependencies:
+    php:
+        composer/composer: '^2'
 
 variables:
     env:

--- a/templates/symfony5/files/.platform.app.yaml
+++ b/templates/symfony5/files/.platform.app.yaml
@@ -6,8 +6,13 @@ name: app
 
 # The type of the application to build.
 type: php:7.4
+
 build:
     flavor: composer
+
+dependencies:
+    php:
+        composer/composer: '^2'
 
 variables:
     env:

--- a/templates/typo3/files/.platform.app.yaml
+++ b/templates/typo3/files/.platform.app.yaml
@@ -9,14 +9,18 @@ name: app
 # The runtime the application uses.
 type: php:7.4
 
+dependencies:
+    php:
+        composer/composer: '^2'
+
 runtime:
     # Enable the redis extension so TYPO3 can communicate with the Redis cache.
     extensions:
         - redis
 
-# Composer build tasks run prior to build hook, which runs 
+# Composer build tasks run prior to build hook, which runs
 # composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
-# if composer.json is detected. 
+# if composer.json is detected.
 build:
     flavor: composer
 
@@ -24,14 +28,14 @@ build:
 # The left-hand side is the name of the relationship as it will be exposed
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
 # side is in the form `<service name>:<endpoint name>`.
-# 
+#
 # NOTE: Be sure to update database and Redis configuration in `public/typo3conf/PlatformshConfiguration.php`
-# if you rename the relationships here.  
+# if you rename the relationships here.
 relationships:
     # MariaDB/MySQL will then be accessible to the app from 'database' relationship.
     # The service name `db` must match the top-level attribute in `.platform/services.yaml`.
     database: 'db:mysql'
-    
+
     # Redis will then be accessible to the app from 'rediscache' relationship.
     # The service name `cache` must match the top-level attribute in `.platform/services.yaml`.
     rediscache: 'cache:redis'
@@ -45,14 +49,14 @@ web:
             # The folder from which to serve static assets, for this location.
             # This is a filesystem path, relative to the application root.
             root: 'public'
-            
+
             # Redirect any incoming request to TYPO3's front controller.
             passthru: '/index.php'
 
             # File to consider first when serving requests for a directory.
             index:
                 - 'index.php'
-            
+
             # Deny access to all static files, except those specifically allowed below.
             allow: false
 
@@ -84,7 +88,7 @@ web:
             allow: true
             passthru: '/index.php'
 
-        # Local TYPO3 installation settings. 
+        # Local TYPO3 installation settings.
         '/typo3conf/LocalConfiguration.php':
             allow: false
 
@@ -97,7 +101,7 @@ disk: 2048
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:
-    # Directory for temporary files. It contains subdirectories (see below) for 
+    # Directory for temporary files. It contains subdirectories (see below) for
     # temporary files of extensions and TYPO3 components.
     "public/typo3temp":
         source: local

--- a/templates/typo3/files/.platform.app.yaml
+++ b/templates/typo3/files/.platform.app.yaml
@@ -9,10 +9,6 @@ name: app
 # The runtime the application uses.
 type: php:7.4
 
-dependencies:
-    php:
-        composer/composer: '^2'
-
 runtime:
     # Enable the redis extension so TYPO3 can communicate with the Redis cache.
     extensions:

--- a/templates/wordpress-bedrock/files/.platform.app.yaml
+++ b/templates/wordpress-bedrock/files/.platform.app.yaml
@@ -11,6 +11,11 @@ type: "php:7.4"
 build:
     flavor: composer
 
+dependencies:
+    php:
+        composer/composer: '^2'
+        wp-cli/wp-cli: "^2.2.0"
+
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed
 # to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
@@ -51,10 +56,6 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
-
-dependencies:
-    php:
-        wp-cli/wp-cli: "^2.2.0"
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/templates/wordpress-composer/files/.platform.app.yaml
+++ b/templates/wordpress-composer/files/.platform.app.yaml
@@ -11,6 +11,11 @@ type: "php:7.4"
 build:
     flavor: composer
 
+dependencies:
+    php:
+        composer/composer: '^2'
+        wp-cli/wp-cli: "^2.2.0"
+
 hooks:
     build: |
         set -e
@@ -58,10 +63,6 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
-
-dependencies:
-    php:
-        wp-cli/wp-cli: "^2.2.0"
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/templates/wordpress-woocommerce/files/.platform.app.yaml
+++ b/templates/wordpress-woocommerce/files/.platform.app.yaml
@@ -7,6 +7,11 @@ name: app
 # The runtime the application uses.
 type: "php:7.4"
 
+dependencies:
+    php:
+        composer/composer: '^2'
+        wp-cli/wp-cli: "^2.2.0"
+
 # Configuration of the build of the application.
 build:
     flavor: composer
@@ -51,10 +56,6 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
-
-dependencies:
-    php:
-        wp-cli/wp-cli: "^2.2.0"
 
 # The mounts that will be performed when the package is deployed.
 mounts:


### PR DESCRIPTION
The ones not listed here broke in local build, likely due to API compatibility issues in Composer plugins.

Merged:
~https://github.com/platformsh-templates/drupal8/pull/41~
~https://github.com/platformsh-templates/laravel/pull/27~
~https://github.com/platformsh-templates/symfony4/pull/22~
~https://github.com/platformsh-templates/symfony5/pull/21~
~https://github.com/platformsh-templates/wordpress-bedrock/pull/3~
~https://github.com/platformsh-templates/wordpress-composer/pull/6~
~https://github.com/platformsh-templates/wordpress-woocommerce/pull/2~
~https://github.com/platformsh-templates/sculpin/pull/19~
~https://github.com/platformsh-templates/drupal8-multisite/pull/22~
~https://github.com/platformsh-templates/drupal9/pull/22~

App isn't ready yet: 
~https://github.com/platformsh-templates/drupal8-opigno/pull/24~

Rest of below not included:

Fixed elsewhere
- https://github.com/platformsh/template-builder/pull/404
    - https://github.com/platformsh-templates/gatsby-wordpress/pull/9
    - https://github.com/platformsh-templates/gatsby-drupal/pull/8

Pending:
https://github.com/platformsh-templates/akeneo/pull/10
https://github.com/platformsh-templates/typo3/pull/16
