### PR TITLE
Updates WooCommerce, Jetpack, WP-CLI

### DIFF
--- a/templates/wordpress-woocommerce/files/.platform.app.yaml
+++ b/templates/wordpress-woocommerce/files/.platform.app.yaml
@@ -10,7 +10,7 @@ type: "php:7.4"
 dependencies:
     php:
         composer/composer: '^2'
-        wp-cli/wp-cli: "^2.2.0"
+        wp-cli/wp-cli-bundle: "^2.5.0"
 
 # Configuration of the build of the application.
 build:


### PR DESCRIPTION
**Updates** 

- WooCommerce to v5.8
- Jetpack to 10.2
- .platform.app.yaml from wp-cli/wp-cli:"^2.2.0" to wp-cli/wp-cli-bundle: "^2.5.0" in php dependencies. This closes https://github.com/platformsh-templates/wordpress-woocommerce/issues/6