### PR TITLE
Wordpress capitalization

### DIFF
--- a/templates/gatsby-wordpress/.platform.template.yaml
+++ b/templates/gatsby-wordpress/.platform.template.yaml
@@ -2,10 +2,10 @@ version: 1
 
 info:
   id: platformsh/gatsby-wordpress
-  name: Gatsby with Wordpress
+  name: Gatsby with WordPress
   description: |
-      <p>This template builds a two application project to deploy the Headless CMS pattern using Gatsby as its frontend and Wordpress for its backend. The `gatsby-source-wordpress` source plugin is used to pull data from Wordpress during the `post_deploy` hook into the Gatsby Data Layer and build the frontend site. Gatsby utilizes the Platform.sh Configuration Reader library for Node.js to define the backend data source in its configuration. It is intended for you to use as a starting point and modify for your own needs.</p>
-      <p>Note that after you have completed the Wordpress installation, the project will require a redeploy to build and deploy Gatsby for the first time. See the included README's post-install section for details.</p>
+      <p>This template builds a two application project to deploy the Headless CMS pattern using Gatsby as its frontend and WordPress for its backend. The `gatsby-source-wordpress` source plugin is used to pull data from WordPress during the `post_deploy` hook into the Gatsby Data Layer and build the frontend site. Gatsby utilizes the Platform.sh Configuration Reader library for Node.js to define the backend data source in its configuration. It is intended for you to use as a starting point and modify for your own needs.</p>
+      <p>Note that after you have completed the WordPress installation, the project will require a redeploy to build and deploy Gatsby for the first time. See the included README's post-install section for details.</p>
       <p>Gatsby is a free and open source framework based on React that helps developers build statically-generated websites and apps, and WordPress is a blogging and lightweight CMS written in PHP.</p>
   tags:
   - Node.js
@@ -23,7 +23,7 @@ info:
           MariaDB 10.4<br />
           Automatic TLS certificates<br />
           npm-based build for Gatsby<br />
-          Composer-based build for Wordpress<br />
+          Composer-based build for WordPress<br />
           Multi-app configuration<br />
           Delayed SSG build (post deploy hook)<br />
 
@@ -35,4 +35,4 @@ initialize:
   repository: git://github.com/platformsh-templates/gatsby-wordpress.git@master
   config: null
   files: []
-  profile: Gatsby with Wordpress
+  profile: Gatsby with WordPress

--- a/templates/wordpress-bedrock/.platform.template.yaml
+++ b/templates/wordpress-bedrock/.platform.template.yaml
@@ -2,7 +2,7 @@ version: 1
 
 info:
   id: platformsh/wordpress-bedrock
-  name: Wordpress (Bedrock)
+  name: WordPress (Bedrock)
   description: |
       <p>This template builds WordPress on Platform.sh using the Bedrock boilerplate by Roots with Composer. Plugins and themes should be managed with Composer exclusively. The only modifications made to the standard Bedrock boilerplate have been providing database credentials and main site url parameters via environment variables. With this configuration, the database is automatically configured such that the installer will not ask you for database credentials. While Bedrock provides support to replicate this configuration in a `.env` file for local development, an example Lando configuration file is included as the recommendated method to do so.</p>
       <p>WordPress is a blogging and lightweight CMS written in PHP, and Bedrock is a Composer-based WordPress boilerplate project with a slightly modified project structure and configuration protocol. </p>
@@ -23,5 +23,5 @@ initialize:
   repository: git://github.com/platformsh-templates/wordpress-bedrock.git@master
   config: null
   files: []
-  profile: Wordpress (Bedrock)
+  profile: WordPress (Bedrock)
 

--- a/templates/wordpress-composer/.platform.template.yaml
+++ b/templates/wordpress-composer/.platform.template.yaml
@@ -2,7 +2,7 @@ version: 1
 
 info:
   id: platformsh/wordpress-composer
-  name: Wordpress (Composer)
+  name: WordPress (Composer)
   description: |
       <p>This template builds WordPress on Platform.sh using the <a href="https://github.com/johnpbloch/wordpress"><code>johnbloch/wordpress</code></a> "Composer Fork" of WordPress.  Plugins and themes should be managed with Composer exclusively.  A custom configuration file is provided that runs on Platform.sh to automatically configure the database, so the installer will not ask you for database credentials.  For local-only configuration you can use a `wp-config-local.php` file that gets excluded from Git.</p>
       <p>WordPress is a blogging and lightweight CMS written in PHP.</p>
@@ -23,4 +23,4 @@ initialize:
   repository: git://github.com/platformsh-templates/wordpress-composer.git@master
   config: null
   files: []
-  profile: Wordpress (Composer)
+  profile: WordPress (Composer)


### PR DESCRIPTION
Capitalizing the "P" in WordPress on templates that had it written as Wordpress. (Change made at request of content team, primarily out of concern for it being correct when template info is pulled into https://platform.sh/) 