### PR TITLE
Fixes issues 11, 12, 13 in bedrock template

### DIFF
--- a/templates/wordpress-bedrock/files/.platform.app.yaml
+++ b/templates/wordpress-bedrock/files/.platform.app.yaml
@@ -14,7 +14,7 @@ build:
 dependencies:
     php:
         composer/composer: '^2'
-        wp-cli/wp-cli: "^2.2.0"
+        wp-cli/wp-cli-bundle: "^2.4.0"
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed
@@ -50,7 +50,7 @@ web:
             scripts: false
             allow: false
         "/wp/wp-content/uploads":
-            root: "web/wp/wp-content/uploads"
+            root: "web/app/uploads"
             scripts: false
             allow: true
 
@@ -62,6 +62,6 @@ mounts:
     "web/app/wp-content/cache":
         source: local
         source_path: "cache"
-    "web/app/wp-content/uploads":
+    "web/app/uploads":
         source: local
         source_path: "uploads"


### PR DESCRIPTION
From [wordpress-bedrock](https://github.com/platformsh-templates/wordpress-bedrock), fixes issues [#11](https://github.com/platformsh-templates/wordpress-bedrock/issues/11), [#12](https://github.com/platformsh-templates/wordpress-bedrock/issues/12), and [#13](https://github.com/platformsh-templates/wordpress-bedrock/issues/13).  
all updates in .platform.app.yaml
**Updates** 
* `dependencies:php:wp-cli/wp-cli` to `wp-cli/wp-cli-bundle`
* `web:locations:"wp/wp-content/uploads":root` from "web/wp/wp-content/uploads" to "web/app/uploads"
* mount from "web/app/wp-content/uploads" to "web/app/uploads":