### PR TITLE
Add source ops

### DIFF
--- a/templates/akeneo/files/.platform.app.yaml
+++ b/templates/akeneo/files/.platform.app.yaml
@@ -160,3 +160,11 @@ workers:
         commands:
             start: |
                 php /app/bin/console akeneo:batch:job-queue-consumer-daemon
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/beego/files/.platform.app.yaml
+++ b/templates/beego/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: golang:1.14
+type: golang:1.16
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:

--- a/templates/beego/files/.platform.app.yaml
+++ b/templates/beego/files/.platform.app.yaml
@@ -38,3 +38,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 1024
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/directus/files/.platform.app.yaml
+++ b/templates/directus/files/.platform.app.yaml
@@ -78,3 +78,11 @@ mounts:
     'var':
         source: local
         source_path: var
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/django2/files/.platform.app.yaml
+++ b/templates/django2/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: 'app'
 
 # The runtime the application uses.
-type: 'python:3.8'
+type: 'python:3.9'
 
 # The build-time dependencies of the app.
 dependencies:

--- a/templates/django2/files/.platform.app.yaml
+++ b/templates/django2/files/.platform.app.yaml
@@ -60,3 +60,11 @@ hooks:
     rm -rf logs
   deploy: |
     python manage.py migrate
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/django3/files/.platform.app.yaml
+++ b/templates/django3/files/.platform.app.yaml
@@ -60,3 +60,11 @@ hooks:
     rm -rf logs
   deploy: |
     python manage.py migrate
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/django4/files/.platform.app.yaml
+++ b/templates/django4/files/.platform.app.yaml
@@ -60,3 +60,11 @@ hooks:
     rm -rf logs
   deploy: |
     python manage.py migrate
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/drupal8-govcms8/files/.platform.app.yaml
+++ b/templates/drupal8-govcms8/files/.platform.app.yaml
@@ -145,3 +145,11 @@ crons:
     drupal:
         spec: '*/19 * * * *'
         cmd: 'cd docroot ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/drupal8-multisite/files/.platform.app.yaml
+++ b/templates/drupal8-multisite/files/.platform.app.yaml
@@ -147,3 +147,11 @@ crons:
     drupal:
         spec: '*/19 * * * *'
         cmd: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/drupal8-opigno/files/.platform.app.yaml
+++ b/templates/drupal8-opigno/files/.platform.app.yaml
@@ -145,3 +145,11 @@ crons:
     drupal:
         spec: '*/19 * * * *'
         cmd: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/drupal8/files/.platform.app.yaml
+++ b/templates/drupal8/files/.platform.app.yaml
@@ -145,3 +145,11 @@ crons:
     drupal:
         spec: '*/19 * * * *'
         cmd: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/drupal9/files/.platform.app.yaml
+++ b/templates/drupal9/files/.platform.app.yaml
@@ -145,3 +145,11 @@ crons:
     drupal:
         spec: '*/19 * * * *'
         cmd: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/echo/files/.platform.app.yaml
+++ b/templates/echo/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: golang:1.14
+type: golang:1.16
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:

--- a/templates/echo/files/.platform.app.yaml
+++ b/templates/echo/files/.platform.app.yaml
@@ -43,3 +43,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 1024
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/express/files/.platform.app.yaml
+++ b/templates/express/files/.platform.app.yaml
@@ -24,3 +24,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 512
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/flask/files/.platform.app.yaml
+++ b/templates/flask/files/.platform.app.yaml
@@ -34,3 +34,11 @@ relationships:
 web:
     commands:
         start: python server.py
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/gatsby/files/.platform.app.yaml
+++ b/templates/gatsby/files/.platform.app.yaml
@@ -34,3 +34,11 @@ web:
             index: ['index.html']
             scripts: false
             allow: true
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/gin/files/.platform.app.yaml
+++ b/templates/gin/files/.platform.app.yaml
@@ -43,3 +43,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 1024
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/golang/files/.platform.app.yaml
+++ b/templates/golang/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: golang:1.15
+type: golang:1.16
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:

--- a/templates/golang/files/.platform.app.yaml
+++ b/templates/golang/files/.platform.app.yaml
@@ -43,3 +43,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 1024
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/koa/files/.platform.app.yaml
+++ b/templates/koa/files/.platform.app.yaml
@@ -21,3 +21,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 512
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/laravel/files/.platform.app.yaml
+++ b/templates/laravel/files/.platform.app.yaml
@@ -99,3 +99,11 @@ crons:
 #            # and get restarted automatically.
 #            start: |
 #                php artisan queue:work --max-time=3600
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -104,3 +104,11 @@ workers:
         commands:
             start: |
                 bin/magento queue:consumers:start async.operations.all --single-thread --max-messages=10000
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/nextjs/files/.platform.app.yaml
+++ b/templates/nextjs/files/.platform.app.yaml
@@ -42,3 +42,11 @@ mounts:
     '/.next':
         source: local
         source_path: 'next'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/nodejs/files/.platform.app.yaml
+++ b/templates/nodejs/files/.platform.app.yaml
@@ -29,3 +29,11 @@ mounts:
     'run':
         source: local
         source_path: run
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/nuxtjs/files/.platform.app.yaml
+++ b/templates/nuxtjs/files/.platform.app.yaml
@@ -25,3 +25,10 @@ hooks:
 web:
   commands:
     start: "yarn start"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate

--- a/templates/pelican/files/.platform.app.yaml
+++ b/templates/pelican/files/.platform.app.yaml
@@ -49,3 +49,11 @@ web:
           allow: true
         ^/robots\.txt$:
           allow: true
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/php/files/.platform.app.yaml
+++ b/templates/php/files/.platform.app.yaml
@@ -50,3 +50,11 @@ web:
             root: "web"
             # The front-controller script to send non-static requests to.
             passthru: "/index.php"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/pimcore/files/.platform.app.yaml
+++ b/templates/pimcore/files/.platform.app.yaml
@@ -105,3 +105,11 @@ crons:
     pimcore_cron:
         spec: "*/5 * * * *"
         cmd: "bin/console maintenance"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/probot/files/.platform.app.yaml
+++ b/templates/probot/files/.platform.app.yaml
@@ -20,3 +20,11 @@ mounts:
 web:
   commands:
     start: "npm start"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/pyramid/files/.platform.app.yaml
+++ b/templates/pyramid/files/.platform.app.yaml
@@ -33,3 +33,11 @@ relationships:
 web:
     commands:
         start: python app.py
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/python3-uwsgi/files/.platform.app.yaml
+++ b/templates/python3-uwsgi/files/.platform.app.yaml
@@ -50,3 +50,11 @@ web:
 
 # The size of the persistent disk of the application (in MB).
 disk: 512
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/python3/files/.platform.app.yaml
+++ b/templates/python3/files/.platform.app.yaml
@@ -34,3 +34,11 @@ relationships:
 web:
     commands:
         start: python server.py
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/rails/files/.platform.app.yaml
+++ b/templates/rails/files/.platform.app.yaml
@@ -107,3 +107,11 @@ web:
 
     commands:
         start: 'bundle exec unicorn -l $SOCKET'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/sculpin/files/.platform.app.yaml
+++ b/templates/sculpin/files/.platform.app.yaml
@@ -47,3 +47,11 @@ web:
           allow: true
         ^/robots\.txt$:
           allow: true
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/strapi/files/.platform.app.yaml
+++ b/templates/strapi/files/.platform.app.yaml
@@ -63,3 +63,10 @@ mounts:
   "public/uploads":
     source: local
     source_path: uploads
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate

--- a/templates/symfony4/files/.platform.app.yaml
+++ b/templates/symfony4/files/.platform.app.yaml
@@ -62,3 +62,11 @@ web:
             # The front-controller script to send non-static requests to.
             passthru: "/index.php"
 
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/symfony5/files/.platform.app.yaml
+++ b/templates/symfony5/files/.platform.app.yaml
@@ -62,3 +62,11 @@ web:
             # The front-controller script to send non-static requests to.
             passthru: "/index.php"
 
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/typo3/files/.platform.app.yaml
+++ b/templates/typo3/files/.platform.app.yaml
@@ -182,3 +182,11 @@ crons:
     typo3:
         spec: "*/5 * * * *"
         cmd: "vendor/bin/typo3 scheduler:run"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/wagtail/files/.platform.app.yaml
+++ b/templates/wagtail/files/.platform.app.yaml
@@ -59,3 +59,11 @@ hooks:
     rm -rf logs
   deploy: |
     python manage.py migrate
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/wordpress-bedrock/files/.platform.app.yaml
+++ b/templates/wordpress-bedrock/files/.platform.app.yaml
@@ -65,3 +65,11 @@ mounts:
     "web/app/uploads":
         source: local
         source_path: "uploads"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/wordpress-composer/files/.platform.app.yaml
+++ b/templates/wordpress-composer/files/.platform.app.yaml
@@ -73,3 +73,11 @@ mounts:
         source: local
         source_path: "uploads"
 
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/gilzow/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    

--- a/templates/wordpress-woocommerce/files/.platform.app.yaml
+++ b/templates/wordpress-woocommerce/files/.platform.app.yaml
@@ -68,3 +68,11 @@ mounts:
     "web/wp/wp-content/uploads":
         source: local
         source_path: "uploads"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/install.sh | bash
+        sourceOp autoupdate
+    


### PR DESCRIPTION
Adds a source:operations block for running automated updates to the .platform.app.yaml file for all templates that use a dependency manager. The following templates were updated:

- akeneo
- beego
- directus
- django2
- django3
- django4
- drupal8-govcms8
- drupal8-multisite
- drupal8-opigno
- drupal8
- drupal9
- echo
- express
- flask
- gatsby
- gin
- golang
- koa
- laravel
- magento2ce
- nextjs
- nodejs
- nuxtjs
- pelican
- php
- pimcore
- probot
- pyramid
- python3-uwsgi
- python3
- rails
- sculpin
- strapi
- symfony4
- symfony5
- typo3
- wagtail
- wordpress-bedrock
- wordpress-composer
- wordpress-woocommerce