### PR TITLE
removes `wp-cli/wp-cli` as a php dependency in .platform.app.yaml

### DIFF
--- a/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
+++ b/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
@@ -14,7 +14,7 @@ build:
 dependencies:
     php:
         composer/composer: '^2'
-        wp-cli/wp-cli: "^2.2.0"
+        wp-cli/wp-cli-bundle: "^2.4.0"
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed

--- a/templates/wordpress-vanilla/files/.platform.app.yaml
+++ b/templates/wordpress-vanilla/files/.platform.app.yaml
@@ -9,7 +9,6 @@ type: "php:7.4"
 
 dependencies:
     php:
-        wp-cli/wp-cli: "^2.2.0"
         wp-cli/wp-cli-bundle: "^2.4"
         psy/psysh: "^0.10.4"
 


### PR DESCRIPTION

closes #509