### PR TITLE
Update drupal.py

### DIFF
--- a/project/drupal.py
+++ b/project/drupal.py
@@ -24,7 +24,7 @@ class Drupal8(RemoteProject):
     def platformify(self):
         return super(Drupal8, self).platformify + [
             # 'cd {0} && composer update -W'.format(self.builddir) + self.composer_defaults()
-            'cd {0} && composer require platformsh/config-reader drush/drush drupal/console drupal/redis'.format(self.builddir)  + self.composer_defaults(),
+            'cd {0} && composer require platformsh/config-reader drush/drush:^10.6 drupal/console drupal/redis'.format(self.builddir)  + self.composer_defaults(),
             # 'cd {0} && composer update -W'.format(self.builddir) + self.composer_defaults()
         ]
 
@@ -58,5 +58,5 @@ class Drupal8_govcms8(RemoteProject):
            # drupal/console only works with the 3.x version, and therefore will fail.
            # It should work to remove the lock file first, but for some reason that is still failing.
            # For now, just skip installing console on GovCMS. I don't know if anyone uses it anyway.
-           'cd {0} && composer require platformsh/config-reader drush/drush drupal/redis'.format(self.builddir) + self.composer_defaults(),
+           'cd {0} && composer require platformsh/config-reader drush/drush:^10.6 drupal/redis'.format(self.builddir) + self.composer_defaults(),
         ]


### PR DESCRIPTION
lock drush to v10.x for d8-based templates
Closes #564 