### PR TITLE
template: wordpress-bedrock, WP_HOME issue fix

### DIFF
--- a/templates/wordpress-bedrock/files/.environment
+++ b/templates/wordpress-bedrock/files/.environment
@@ -4,8 +4,8 @@ export DB_PORT=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".databa
 export DB_USER=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].username")
 export DB_PASSWORD=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].password")
 
-export WP_HOME=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key')
-export WP_SITEURL="${WP_HOME}wp"
+export WP_HOME=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key' | sed 's:/*$::')
+export WP_SITEURL="${WP_HOME}/wp"
 export WP_DEBUG_LOG=/var/log/app.log
 export WP_ENV=production
 # Uncomment this line if you would like development versions of WordPress on non-production environments.


### PR DESCRIPTION
Closes #638 
Removes trailing slash from url before assigning it to WP_HOME
adds slash between WP_HOME and 'wp' before assigning it to WP_SITEURL