### PR TITLE
whitelist serveable file

### DIFF
--- a/templates/wordpress-bedrock/files/.platform.app.yaml
+++ b/templates/wordpress-bedrock/files/.platform.app.yaml
@@ -52,7 +52,12 @@ web:
         "/wp/wp-content/uploads":
             root: "web/app/uploads"
             scripts: false
-            allow: true
+            allow: false
+            rules:
+                # Allow access to common static files.
+                '(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$':
+                    allow: true
+                    expires: 1w
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
@@ -71,4 +76,4 @@ source:
     auto-update:
       command: |
         curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
-    
+

--- a/templates/wordpress-composer/files/.platform.app.yaml
+++ b/templates/wordpress-composer/files/.platform.app.yaml
@@ -59,7 +59,12 @@ web:
         "/wp-content/uploads":
             root: "wordpress/wp-content/uploads"
             scripts: false
-            allow: true
+            allow: false
+            rules:
+                # Allow access to common static files.
+                '(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$':
+                    allow: true
+                    expires: 1w
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
@@ -79,4 +84,4 @@ source:
     auto-update:
       command: |
         curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
-    
+

--- a/templates/wordpress-vanilla/files/.platform.app.yaml
+++ b/templates/wordpress-vanilla/files/.platform.app.yaml
@@ -48,7 +48,12 @@ web:
         "/wp-content/uploads":
             root: "wordpress/wp-content/uploads"
             scripts: false
-            allow: true
+            allow: false
+            rules:
+                # Allow access to common static files.
+                '(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$':
+                    allow: true
+                    expires: 1w
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/templates/wordpress-woocommerce/files/.platform.app.yaml
+++ b/templates/wordpress-woocommerce/files/.platform.app.yaml
@@ -52,7 +52,12 @@ web:
         "/wp/wp-content/uploads":
             root: "web/wp/wp-content/uploads"
             scripts: false
-            allow: true
+            allow: false
+            rules:
+                # Allow access to common static files.
+                '(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$':
+                    allow: true
+                    expires: 1w
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
@@ -74,4 +79,4 @@ source:
     auto-update:
       command: |
         curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
-    
+


### PR DESCRIPTION
adds `allow: false` to `wp-content/uploads` and then an override rule with `allow: true` against a whitelist of file extensions

Whitelist:
`(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$`

For those file extensions, adds a cache expires of 1w

[Closes issue 75 in WordPress Bedrock template.](https://github.com/platformsh-templates/wordpress-bedrock/issues/75)