### PR TITLE
Feat/661 sourceop GitHub workflow

### DIFF
--- a/common/sourceop-auto-update/.github/workflows/autopr.yaml
+++ b/common/sourceop-auto-update/.github/workflows/autopr.yaml
@@ -1,0 +1,29 @@
+name: Trigger Auto PR on push to update branch
+on:
+  push:
+    branches:
+      - update
+  workflow_dispatch:
+
+env:
+  PLATFORMSH_CLI_TOKEN: ${{ secrets.TEMPLATES_CLI_TOKEN }}
+
+jobs:
+  create-auto-pr:
+    name: "Creates an auto merging PR when the branch is updated"
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'platformsh-templates' }}
+    steps:
+      - name: 'Prep the repo for autoPR'
+        id: prepautopr
+        uses: platformsh/gha-prep-for-autopr@main
+        with:
+          github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+
+      - name: 'Create & merge PR'
+        id: create-merge-pr
+        uses: platformsh/gha-create-autopr@main
+        with:
+          github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+          trigger-source: 'auto push'
+          default-branch: ${{ steps.prepautopr.outputs.default-branch }}

--- a/common/sourceop-auto-update/.github/workflows/sourceops.yaml
+++ b/common/sourceop-auto-update/.github/workflows/sourceops.yaml
@@ -13,7 +13,7 @@ jobs:
   run_dm_update:
     name: Trigger Source Op
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'gilzow' }}
+    if: ${{ github.repository_owner == 'platformsh-templates' }}
     steps:
       - name: 'Setup Python'
         uses: actions/setup-python@v2

--- a/common/sourceop-auto-update/.github/workflows/sourceops.yaml
+++ b/common/sourceop-auto-update/.github/workflows/sourceops.yaml
@@ -1,0 +1,57 @@
+name: Trigger Source Operations on a Schedule
+on:
+  schedule:
+    # Run at 00:15 every day
+    - cron: '15 0 * * *'
+  workflow_dispatch:
+
+env:
+  PLATFORMSH_CLI_TOKEN: ${{ secrets.TEMPLATES_CLI_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+
+jobs:
+  run_dm_update:
+    name: Trigger Source Op
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'gilzow' }}
+    steps:
+      - name: 'Setup Python'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: "Install PSH CLI tool"
+        run: |
+          curl -fsS https://platform.sh/cli/installer | php
+          # for some reason, sourcing our .bashrc file does not successfully prepend our path to PATH
+          export PATH="${HOME}/.platformsh/bin:${PATH}"
+      - uses: actions/checkout@v2
+      - name: 'Get project ID'
+        run: |
+          # grab the array entries where config.url contain 'platform.sh' then map back to an array. if our
+          # array length is 1, return the entry for config.url, otherwise return error
+          integrationURL=$(gh api "/repos/${{ github.repository }}/hooks" | jq 'map(select(.config.url | contains("platform.sh"))) | if . | length == 1 then .[0].config.url else "error" end')
+          if [[ "error" == "${integrationURL}" ]]; then
+              echo "::error::Either more than one webhook, or zero webhooks were returned. I was expecting just one."
+              exit 1
+          fi
+
+          projIDpttrn='\/projects\/([^\/]+)\/integrations'
+          if [[ "${integrationURL}" =~ ${projIDpttrn} ]]; then
+               echo "PLATFORMSH_PROJECT=${BASH_REMATCH[1]}" >> $GITHUB_ENV
+               echo "::notice::Project ID is ${BASH_REMATCH[1]}"
+               #echo "::set-output name=projectID::${BASH_REMATCH[1]}"
+          else
+              echo "::error::We were unable to extract the project ID from the integration url of ${integrationURL}"
+              exit 1
+          fi
+
+      - name: 'Run SourceOp Tools'
+        run: |
+          if [[ "${PATH}" != *".platformsh"* ]]; then
+            echo "psh installer not in PATH"
+            export PATH="${HOME}/.platformsh/bin:${PATH}"
+          fi
+          printf "Beginning Source Operations toolkit install...\n"
+
+          curl -fsS https://raw.githubusercontent.com/gilzow/source-operations-debug/main/setup.sh | { bash /dev/fd/3 trigger-sopupdate; } 3<&0
+

--- a/common/sourceop-auto-update/.github/workflows/testprenvironment.yaml
+++ b/common/sourceop-auto-update/.github/workflows/testprenvironment.yaml
@@ -1,0 +1,38 @@
+name: "TestPrEnvironment"
+on:
+  workflow_run:
+    workflows: [ "platformsh" ]
+    types:
+      - completed
+  pull_request:
+    branches:
+      - master
+env:
+  GITHUB_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
+jobs:
+  test-pr-env:
+    name: TestPrEnvironment
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'platformsh-templates' }}
+    steps:
+      - name: 'Wait for psh and get target url'
+        id: get-target-url
+        uses: platformsh/gha-retrieve-psh-prenv-url@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Does Our App Work?'
+        id: test-environment
+        run: |
+          target_url=${{ steps.get-target-url.outputs.target_url }}
+          echo "::notice::The target url returned from our github action: ${target_url}"
+          #ok, so for whatever strange reason, our integration returns the http version of the PR environment, not https
+          #hence to parameter expansion replacement.
+          #we dont need the whole response (yet), just see if we get a 200
+          response=$(curl -s -o /dev/null -I -w "%{http_code}" "${target_url//http:/https:}");
+          if [[ "200" == "${response}" ]]; then
+            echo "::notice::Environment responded with http header 200"
+          else
+            echo "::error::Response from environment was something other than 200. Response returned was ${response}"
+            exit 1;
+          fi
+


### PR DESCRIPTION
Adds github workflow files to `common/sourceop-auto-update/` for performing scheduled source operations, auto PRs, a smoke test. 

Adds a check for `source:operations:auto-update` in the templates `.platform.app.yaml` file, and if present, copies the contents from `common/sourceop-auto-update` into the template's build directory.

Closes #661 
