### PR TITLE
Update/697 cli install instructions

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -55,8 +55,13 @@ def project_factory(name):
     except KeyError:
         return BaseProject(name)
 
-ALL_PROJECTS = [project_factory(f.name) for f in os.scandir(TEMPLATEDIR)
-                if f.is_dir() and f.name not in IGNORED]
+
+if ':' in sys.argv[1]:
+    ALL_PROJECTS = [project_factory(f.name) for f in os.scandir(TEMPLATEDIR)
+                    if f.is_dir() and f.name not in IGNORED and f.name == sys.argv[1].split(':')[1]]
+else:
+    ALL_PROJECTS = [project_factory(f.name) for f in os.scandir(TEMPLATEDIR)
+                    if f.is_dir() and f.name not in IGNORED]
 
 def task_cleanup():
     """

--- a/dodo.py
+++ b/dodo.py
@@ -6,6 +6,7 @@ In case the actions of some tasks need to be customized, the new BaseProject sub
 '''
 
 import os
+import sys
 
 from project import BaseProject, TEMPLATEDIR
 from project.akeneo import Akeneo

--- a/templates/drupal8-govcms8/files/README.md
+++ b/templates/drupal8-govcms8/files/README.md
@@ -78,7 +78,7 @@ GovCMS is a Drupal distribution built for the Australian government, and include
 #### Quickstart
 
 
-The quickest way to deploy this template on Platform.sh is by clicking the button below. 
+The quickest way to deploy this template on Platform.sh is by clicking the button below.
 This will automatically create a new project and initialize the repository for you.
 
 <p align="center">
@@ -97,7 +97,7 @@ composer create-project platformsh/govcms9 -s dev
 ```
 
 
-> **Note:**    
+> **Note:**
 >
 > Platform.sh templates prioritize upstream release versions over our own. Despite this, we update template dependencies on a scheduled basis independent of those upstreams. Because of this, template repos do not contain releases. This may change in the future, but until then the `-s dev` flag is necessary to use `composer create-project`.
 
@@ -111,7 +111,7 @@ For all of the other options below, clone this repository first:
 git clone https://github.com/platformsh-templates/drupal8-govcms8
 ```
 
-If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8-govcms8/generate) button at the top of this page. 
+If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8-govcms8/generate) button at the top of this page.
 
 Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAMESPACE/drupal8-govcms8.git`.
 
@@ -127,24 +127,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -161,7 +161,7 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -177,17 +177,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -211,24 +211,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -249,24 +249,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -286,7 +286,7 @@ Run through the Drupal installer as normal.  You will not be asked for database 
 
 This section provides instructions for running the `drupal8-govcms8` template locally, connected to a live database instance on an active Platform.sh environment.
 
-In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally. 
+In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally.
 Each of the options below assume that you have already deployed this template to Platform.sh, as well as the following starting commands:
 
 ```bash
@@ -298,14 +298,14 @@ $ platform environment:branch updates
 <details>
 <summary>Drupal: using ddev</summary><br />
 
-ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information. 
+ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information.
 
 In general, the steps are as follows:
 
 1. [Install ddev](https://ddev.readthedocs.io/en/stable/#installation).
 1. A configuration file has already been provided at `.ddev/providers/platform.yaml`, so you should not need to run `ddev config`.
 1. [Retrieve an API token](https://docs.platform.sh/development/cli/api-tokens.html#get-a-token) for your organization via the management console.
-1. Update your dedev global configuration file to use the token you've just retrieved: 
+1. Update your dedev global configuration file to use the token you've just retrieved:
     ```yaml
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
@@ -319,14 +319,14 @@ In general, the steps are as follows:
     environment: CURRENT_ENVIRONMENT
     application: drupal
     ```
-1. Get the current environment's data with `ddev pull platform`. 
+1. Get the current environment's data with `ddev pull platform`.
 1. When you have finished with your work, run `ddev stop` and `ddev poweroff`.
 
 </details>
 <details>
 <summary>Drupal: using Lando</summary><br />
 
-Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/). 
+Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/).
 
 1. [Install Lando](https://docs.lando.dev/getting-started/installation.html).
 1. Make sure Docker is already running - Lando will attempt to start Docker for you, but it's best to have it running in the background before beginning.
@@ -361,7 +361,7 @@ If you already have code you'd like to migrate, feel free to focus on the steps 
 
 ### Getting started
 
-Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh. 
+Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh.
 If you already have a codebase you are trying to migrate, move onto the next step - [Adding and updating files](#adding-and-updating-files) - and substitute any reference to the default branch `main` with some other branch name.
 
 
@@ -381,7 +381,7 @@ $ git merge --allow-unrelated-histories -X theirs 2.12.0
 
 ### Adding and updating files
 
-A small number of files need to be added to or modified in your repository at this point. 
+A small number of files need to be added to or modified in your repository at this point.
 Some of them explicitly configure how the application is built and deployed on Platform.sh, while others simply modify files you may already have locally, in which case you will need to replicate those changes.
 
 Open the dropdown below to view all of the **Added** and **Updated** files you'll need to reproduce in your migration.
@@ -415,9 +415,9 @@ Open the dropdown below to view all of the **Added** and **Updated** files you'l
 
 ### Dependencies and configuration
 
-Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh. 
-When it is, we do our best to keep these modifications to the minimum necessary. 
-Run the commands below to reproduce the dependencies in this template. 
+Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh.
+When it is, we do our best to keep these modifications to the minimum necessary.
+Run the commands below to reproduce the dependencies in this template.
 
 
 
@@ -426,7 +426,7 @@ $ composer require platformsh/config-reader drush/drush:^10 drupal/redis
 $ composer config allow-plugins.composer/installers true --no-plugins
 $ composer config allow-plugins.drupal/core-composer-scaffold true --no-plugins
 $ composer config allow-plugins.drupal/core-project-message true --no-plugins
-$ composer config allow-plugins.cweagans/composer-patches true --no-plugins 
+$ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ```
 
@@ -434,7 +434,7 @@ $ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ### Deploying to Platform.sh
 
-Your repository now has all of the code it needs in order to deploy to Platform.sh. 
+Your repository now has all of the code it needs in order to deploy to Platform.sh.
 
 
 <details>
@@ -448,24 +448,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -482,7 +482,7 @@ Your repository now has all of the code it needs in order to deploy to Platform.
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -498,17 +498,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -532,24 +532,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -570,24 +570,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -617,12 +617,12 @@ platform sql -e main < database.sql
 <details>
 <summary>Importing files</summary><br/>
 
-You first need to download your files from your current hosting environment. 
-The easiest way is likely with rsync, but consult your old host's documentation. 
+You first need to download your files from your current hosting environment.
+The easiest way is likely with rsync, but consult your old host's documentation.
 
-The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file. 
-Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible. 
-(There is also a `platform mount:download` command you can use to download files later.) 
+The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file.
+Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible.
+(There is also a `platform mount:download` command you can use to download files later.)
 Run the following from your local Git repository root (modifying the `--source` path if needed and setting `BRANCH_NAME` to the branch you are using).
 
 A few examples are listed below, but repeat for all directories that contain data you would like to migrate.
@@ -640,12 +640,12 @@ Note that `rsync` is picky about its trailing slashes, so be sure to include tho
 
 ### Next steps
 
-With your application now deployed on Platform.sh, things get more interesting. 
-Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch. 
+With your application now deployed on Platform.sh, things get more interesting.
+Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch.
 
 The resulting environment is an *exact* copy of production.
-It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services. 
-On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production. 
+It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services.
+On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production.
 
 After that, here are a collection of additional resources you might find interesting as you continue with your migration to Platform.sh:
 
@@ -672,7 +672,7 @@ After the environment has finished its deployment, you can investigate issues th
 platform ssh
 ```
 
-If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well. 
+If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well.
 Once you have connected to the container, [logs](https://docs.platform.sh/development/logs.html#container-logs) are available within `/var/log/` for you to investigate.
 
 </details>
@@ -706,7 +706,7 @@ In the past, Platform.sh templates have overridden this value:
 $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 ```
 
-This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`. 
+This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`.
 
 Now, the setting looks like this in `settings.platformsh.php`:
 
@@ -714,7 +714,7 @@ Now, the setting looks like this in `settings.platformsh.php`:
 $settings['hash_salt'] = empty($settings['hash_salt']) ? $platformsh->projectEntropy : $settings['hash_salt'];
 ```
 
-This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`. 
+This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`.
 If your application code *depends* on an empty value, feel free to comment out that line, or reset again later in that file.
 
 Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platformsh-templates/drupal9/pull/73) for more details on this discussion.
@@ -726,7 +726,7 @@ Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platfo
 
 ### Blackfire.io: creating a Continuous Observability Strategy
 
-This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html). 
+This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html).
 
 * [What is Blackfire?](https://blackfire.io/docs/introduction)
 * [Configuring Blackfire.io on a Platform.sh project](https://docs.platform.sh/integrations/observability/blackfire.html)
@@ -769,7 +769,7 @@ Our key features include:
 
 * **GitOps: Git as the source of truth**
 
-    Every branch becomes a development environment, and nothing can change without a commit. 
+    Every branch becomes a development environment, and nothing can change without a commit.
 
 * **Batteries included: Managed infrastructure**
 
@@ -777,11 +777,11 @@ Our key features include:
 
 * **Instant cloning: Branch, merge, repeat**
 
-    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.  
+    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.
 
 * **FleetOps: Fleet management platform**
 
-    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code. 
+    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code.
 
 
 To find out more, check out the demo below and go to our [website](https://platform.sh/product/).
@@ -800,7 +800,7 @@ To find out more, check out the demo below and go to our [website](https://platf
 
 <h3 align="center">Help us keep top-notch templates!</h3>
 
-Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks. 
+Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks.
 
 See something that's wrong with this template that needs to be fixed? Something in the documentation unclear or missing? Let us know!
 

--- a/templates/drupal8-multisite/files/README.md
+++ b/templates/drupal8-multisite/files/README.md
@@ -83,7 +83,7 @@ Drupal is a flexible and extensible PHP-based CMS framework capable of hosting m
 #### Quickstart
 
 
-The quickest way to deploy this template on Platform.sh is by clicking the button below. 
+The quickest way to deploy this template on Platform.sh is by clicking the button below.
 This will automatically create a new project and initialize the repository for you.
 
 <p align="center">
@@ -102,7 +102,7 @@ composer create-project platformsh/drupal8-multisite -s dev
 ```
 
 
-> **Note:**    
+> **Note:**
 >
 > Platform.sh templates prioritize upstream release versions over our own. Despite this, we update template dependencies on a scheduled basis independent of those upstreams. Because of this, template repos do not contain releases. This may change in the future, but until then the `-s dev` flag is necessary to use `composer create-project`.
 
@@ -116,7 +116,7 @@ For all of the other options below, clone this repository first:
 git clone https://github.com/platformsh-templates/drupal8-multisite
 ```
 
-If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8-multisite/generate) button at the top of this page. 
+If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8-multisite/generate) button at the top of this page.
 
 Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAMESPACE/drupal8-multisite.git`.
 
@@ -132,24 +132,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -166,7 +166,7 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -182,17 +182,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -216,24 +216,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -254,24 +254,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -290,7 +290,7 @@ Each subsite installs separately. As configured, this project uses a subdomain f
 
 This section provides instructions for running the `drupal8-multisite` template locally, connected to a live database instance on an active Platform.sh environment.
 
-In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally. 
+In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally.
 Each of the options below assume that you have already deployed this template to Platform.sh, as well as the following starting commands:
 
 ```bash
@@ -302,14 +302,14 @@ $ platform environment:branch updates
 <details>
 <summary>Drupal: using ddev</summary><br />
 
-ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information. 
+ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information.
 
 In general, the steps are as follows:
 
 1. [Install ddev](https://ddev.readthedocs.io/en/stable/#installation).
 1. A configuration file has already been provided at `.ddev/providers/platform.yaml`, so you should not need to run `ddev config`.
 1. [Retrieve an API token](https://docs.platform.sh/development/cli/api-tokens.html#get-a-token) for your organization via the management console.
-1. Update your dedev global configuration file to use the token you've just retrieved: 
+1. Update your dedev global configuration file to use the token you've just retrieved:
     ```yaml
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
@@ -323,14 +323,14 @@ In general, the steps are as follows:
     environment: CURRENT_ENVIRONMENT
     application: drupal
     ```
-1. Get the current environment's data with `ddev pull platform`. 
+1. Get the current environment's data with `ddev pull platform`.
 1. When you have finished with your work, run `ddev stop` and `ddev poweroff`.
 
 </details>
 <details>
 <summary>Drupal: using Lando</summary><br />
 
-Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/). 
+Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/).
 
 1. [Install Lando](https://docs.lando.dev/getting-started/installation.html).
 1. Make sure Docker is already running - Lando will attempt to start Docker for you, but it's best to have it running in the background before beginning.
@@ -365,7 +365,7 @@ If you already have code you'd like to migrate, feel free to focus on the steps 
 
 ### Getting started
 
-Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh. 
+Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh.
 If you already have a codebase you are trying to migrate, move onto the next step - [Adding and updating files](#adding-and-updating-files) - and substitute any reference to the default branch `main` with some other branch name.
 
 
@@ -385,7 +385,7 @@ $ git merge --allow-unrelated-histories -X theirs 8.9.20
 
 ### Adding and updating files
 
-A small number of files need to be added to or modified in your repository at this point. 
+A small number of files need to be added to or modified in your repository at this point.
 Some of them explicitly configure how the application is built and deployed on Platform.sh, while others simply modify files you may already have locally, in which case you will need to replicate those changes.
 
 Open the dropdown below to view all of the **Added** and **Updated** files you'll need to reproduce in your migration.
@@ -421,9 +421,9 @@ Open the dropdown below to view all of the **Added** and **Updated** files you'l
 
 ### Dependencies and configuration
 
-Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh. 
-When it is, we do our best to keep these modifications to the minimum necessary. 
-Run the commands below to reproduce the dependencies in this template. 
+Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh.
+When it is, we do our best to keep these modifications to the minimum necessary.
+Run the commands below to reproduce the dependencies in this template.
 
 
 
@@ -432,7 +432,7 @@ $ composer require platformsh/config-reader drush/drush:^10.6 drupal/console dru
 $ composer config allow-plugins.composer/installers true --no-plugins
 $ composer config allow-plugins.drupal/core-composer-scaffold true --no-plugins
 $ composer config allow-plugins.drupal/core-project-message true --no-plugins
-$ composer config allow-plugins.cweagans/composer-patches true --no-plugins 
+$ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ```
 
@@ -440,7 +440,7 @@ $ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ### Deploying to Platform.sh
 
-Your repository now has all of the code it needs in order to deploy to Platform.sh. 
+Your repository now has all of the code it needs in order to deploy to Platform.sh.
 
 
 <details>
@@ -454,24 +454,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -488,7 +488,7 @@ Your repository now has all of the code it needs in order to deploy to Platform.
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -504,17 +504,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -538,24 +538,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -576,24 +576,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -623,12 +623,12 @@ platform sql -e main < database.sql
 <details>
 <summary>Importing files</summary><br/>
 
-You first need to download your files from your current hosting environment. 
-The easiest way is likely with rsync, but consult your old host's documentation. 
+You first need to download your files from your current hosting environment.
+The easiest way is likely with rsync, but consult your old host's documentation.
 
-The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file. 
-Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible. 
-(There is also a `platform mount:download` command you can use to download files later.) 
+The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file.
+Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible.
+(There is also a `platform mount:download` command you can use to download files later.)
 Run the following from your local Git repository root (modifying the `--source` path if needed and setting `BRANCH_NAME` to the branch you are using).
 
 A few examples are listed below, but repeat for all directories that contain data you would like to migrate.
@@ -646,12 +646,12 @@ Note that `rsync` is picky about its trailing slashes, so be sure to include tho
 
 ### Next steps
 
-With your application now deployed on Platform.sh, things get more interesting. 
-Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch. 
+With your application now deployed on Platform.sh, things get more interesting.
+Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch.
 
 The resulting environment is an *exact* copy of production.
-It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services. 
-On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production. 
+It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services.
+On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production.
 
 After that, here are a collection of additional resources you might find interesting as you continue with your migration to Platform.sh:
 
@@ -678,7 +678,7 @@ After the environment has finished its deployment, you can investigate issues th
 platform ssh
 ```
 
-If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well. 
+If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well.
 Once you have connected to the container, [logs](https://docs.platform.sh/development/logs.html#container-logs) are available within `/var/log/` for you to investigate.
 
 </details>
@@ -712,7 +712,7 @@ In the past, Platform.sh templates have overridden this value:
 $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 ```
 
-This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`. 
+This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`.
 
 Now, the setting looks like this in `settings.platformsh.php`:
 
@@ -720,7 +720,7 @@ Now, the setting looks like this in `settings.platformsh.php`:
 $settings['hash_salt'] = empty($settings['hash_salt']) ? $platformsh->projectEntropy : $settings['hash_salt'];
 ```
 
-This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`. 
+This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`.
 If your application code *depends* on an empty value, feel free to comment out that line, or reset again later in that file.
 
 Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platformsh-templates/drupal9/pull/73) for more details on this discussion.
@@ -778,7 +778,7 @@ Any Drush command can therefore be used on a specific subsite by using `--uri=`.
 
 ### Blackfire.io: creating a Continuous Observability Strategy
 
-This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html). 
+This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html).
 
 * [What is Blackfire?](https://blackfire.io/docs/introduction)
 * [Configuring Blackfire.io on a Platform.sh project](https://docs.platform.sh/integrations/observability/blackfire.html)
@@ -821,7 +821,7 @@ Our key features include:
 
 * **GitOps: Git as the source of truth**
 
-    Every branch becomes a development environment, and nothing can change without a commit. 
+    Every branch becomes a development environment, and nothing can change without a commit.
 
 * **Batteries included: Managed infrastructure**
 
@@ -829,11 +829,11 @@ Our key features include:
 
 * **Instant cloning: Branch, merge, repeat**
 
-    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.  
+    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.
 
 * **FleetOps: Fleet management platform**
 
-    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code. 
+    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code.
 
 
 To find out more, check out the demo below and go to our [website](https://platform.sh/product/).
@@ -852,7 +852,7 @@ To find out more, check out the demo below and go to our [website](https://platf
 
 <h3 align="center">Help us keep top-notch templates!</h3>
 
-Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks. 
+Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks.
 
 See something that's wrong with this template that needs to be fixed? Something in the documentation unclear or missing? Let us know!
 

--- a/templates/drupal8-opigno/files/README.md
+++ b/templates/drupal8-opigno/files/README.md
@@ -77,7 +77,7 @@ Opigno is a Learning Management system built as a Drupal distribution.
 #### Quickstart
 
 
-The quickest way to deploy this template on Platform.sh is by clicking the button below. 
+The quickest way to deploy this template on Platform.sh is by clicking the button below.
 This will automatically create a new project and initialize the repository for you.
 
 <p align="center">
@@ -96,7 +96,7 @@ composer create-project platformsh/opigno-composer -s dev
 ```
 
 
-> **Note:**    
+> **Note:**
 >
 > Platform.sh templates prioritize upstream release versions over our own. Despite this, we update template dependencies on a scheduled basis independent of those upstreams. Because of this, template repos do not contain releases. This may change in the future, but until then the `-s dev` flag is necessary to use `composer create-project`.
 
@@ -110,7 +110,7 @@ For all of the other options below, clone this repository first:
 git clone https://github.com/platformsh-templates/drupal8-opigno
 ```
 
-If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8-opigno/generate) button at the top of this page. 
+If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8-opigno/generate) button at the top of this page.
 
 Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAMESPACE/drupal8-opigno.git`.
 
@@ -126,24 +126,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -160,7 +160,7 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -176,17 +176,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -210,24 +210,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -248,24 +248,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -291,7 +291,7 @@ After you have logged in for the first time, be sure to update your email and pa
 
 This section provides instructions for running the `drupal8-opigno` template locally, connected to a live database instance on an active Platform.sh environment.
 
-In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally. 
+In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally.
 Each of the options below assume that you have already deployed this template to Platform.sh, as well as the following starting commands:
 
 ```bash
@@ -303,14 +303,14 @@ $ platform environment:branch updates
 <details>
 <summary>Drupal: using ddev</summary><br />
 
-ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information. 
+ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information.
 
 In general, the steps are as follows:
 
 1. [Install ddev](https://ddev.readthedocs.io/en/stable/#installation).
 1. A configuration file has already been provided at `.ddev/providers/platform.yaml`, so you should not need to run `ddev config`.
 1. [Retrieve an API token](https://docs.platform.sh/development/cli/api-tokens.html#get-a-token) for your organization via the management console.
-1. Update your dedev global configuration file to use the token you've just retrieved: 
+1. Update your dedev global configuration file to use the token you've just retrieved:
     ```yaml
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
@@ -324,14 +324,14 @@ In general, the steps are as follows:
     environment: CURRENT_ENVIRONMENT
     application: drupal
     ```
-1. Get the current environment's data with `ddev pull platform`. 
+1. Get the current environment's data with `ddev pull platform`.
 1. When you have finished with your work, run `ddev stop` and `ddev poweroff`.
 
 </details>
 <details>
 <summary>Drupal: using Lando</summary><br />
 
-Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/). 
+Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/).
 
 1. [Install Lando](https://docs.lando.dev/getting-started/installation.html).
 1. Make sure Docker is already running - Lando will attempt to start Docker for you, but it's best to have it running in the background before beginning.
@@ -366,7 +366,7 @@ If you already have code you'd like to migrate, feel free to focus on the steps 
 
 ### Getting started
 
-Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh. 
+Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh.
 If you already have a codebase you are trying to migrate, move onto the next step - [Adding and updating files](#adding-and-updating-files) - and substitute any reference to the default branch `main` with some other branch name.
 
 
@@ -386,7 +386,7 @@ $ git merge --allow-unrelated-histories -X theirs 2.29.0
 
 ### Adding and updating files
 
-A small number of files need to be added to or modified in your repository at this point. 
+A small number of files need to be added to or modified in your repository at this point.
 Some of them explicitly configure how the application is built and deployed on Platform.sh, while others simply modify files you may already have locally, in which case you will need to replicate those changes.
 
 Open the dropdown below to view all of the **Added** and **Updated** files you'll need to reproduce in your migration.
@@ -419,9 +419,9 @@ Open the dropdown below to view all of the **Added** and **Updated** files you'l
 
 ### Dependencies and configuration
 
-Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh. 
-When it is, we do our best to keep these modifications to the minimum necessary. 
-Run the commands below to reproduce the dependencies in this template. 
+Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh.
+When it is, we do our best to keep these modifications to the minimum necessary.
+Run the commands below to reproduce the dependencies in this template.
 
 
 
@@ -430,7 +430,7 @@ $ composer require platformsh/config-reader drush/drush:^9.1 drupal/console drup
 $ composer config allow-plugins.composer/installers true --no-plugins
 $ composer config allow-plugins.drupal/core-composer-scaffold true --no-plugins
 $ composer config allow-plugins.drupal/core-project-message true --no-plugins
-$ composer config allow-plugins.cweagans/composer-patches true --no-plugins 
+$ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ```
 
@@ -438,7 +438,7 @@ $ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ### Deploying to Platform.sh
 
-Your repository now has all of the code it needs in order to deploy to Platform.sh. 
+Your repository now has all of the code it needs in order to deploy to Platform.sh.
 
 
 <details>
@@ -452,24 +452,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -486,7 +486,7 @@ Your repository now has all of the code it needs in order to deploy to Platform.
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -502,17 +502,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -536,24 +536,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -574,24 +574,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -621,12 +621,12 @@ platform sql -e main < database.sql
 <details>
 <summary>Importing files</summary><br/>
 
-You first need to download your files from your current hosting environment. 
-The easiest way is likely with rsync, but consult your old host's documentation. 
+You first need to download your files from your current hosting environment.
+The easiest way is likely with rsync, but consult your old host's documentation.
 
-The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file. 
-Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible. 
-(There is also a `platform mount:download` command you can use to download files later.) 
+The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file.
+Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible.
+(There is also a `platform mount:download` command you can use to download files later.)
 Run the following from your local Git repository root (modifying the `--source` path if needed and setting `BRANCH_NAME` to the branch you are using).
 
 A few examples are listed below, but repeat for all directories that contain data you would like to migrate.
@@ -644,12 +644,12 @@ Note that `rsync` is picky about its trailing slashes, so be sure to include tho
 
 ### Next steps
 
-With your application now deployed on Platform.sh, things get more interesting. 
-Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch. 
+With your application now deployed on Platform.sh, things get more interesting.
+Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch.
 
 The resulting environment is an *exact* copy of production.
-It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services. 
-On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production. 
+It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services.
+On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production.
 
 After that, here are a collection of additional resources you might find interesting as you continue with your migration to Platform.sh:
 
@@ -676,7 +676,7 @@ After the environment has finished its deployment, you can investigate issues th
 platform ssh
 ```
 
-If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well. 
+If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well.
 Once you have connected to the container, [logs](https://docs.platform.sh/development/logs.html#container-logs) are available within `/var/log/` for you to investigate.
 
 </details>
@@ -710,7 +710,7 @@ In the past, Platform.sh templates have overridden this value:
 $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 ```
 
-This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`. 
+This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`.
 
 Now, the setting looks like this in `settings.platformsh.php`:
 
@@ -718,7 +718,7 @@ Now, the setting looks like this in `settings.platformsh.php`:
 $settings['hash_salt'] = empty($settings['hash_salt']) ? $platformsh->projectEntropy : $settings['hash_salt'];
 ```
 
-This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`. 
+This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`.
 If your application code *depends* on an empty value, feel free to comment out that line, or reset again later in that file.
 
 Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platformsh-templates/drupal9/pull/73) for more details on this discussion.
@@ -730,7 +730,7 @@ Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platfo
 
 ### Blackfire.io: creating a Continuous Observability Strategy
 
-This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html). 
+This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html).
 
 * [What is Blackfire?](https://blackfire.io/docs/introduction)
 * [Configuring Blackfire.io on a Platform.sh project](https://docs.platform.sh/integrations/observability/blackfire.html)
@@ -773,7 +773,7 @@ Our key features include:
 
 * **GitOps: Git as the source of truth**
 
-    Every branch becomes a development environment, and nothing can change without a commit. 
+    Every branch becomes a development environment, and nothing can change without a commit.
 
 * **Batteries included: Managed infrastructure**
 
@@ -781,11 +781,11 @@ Our key features include:
 
 * **Instant cloning: Branch, merge, repeat**
 
-    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.  
+    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.
 
 * **FleetOps: Fleet management platform**
 
-    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code. 
+    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code.
 
 
 To find out more, check out the demo below and go to our [website](https://platform.sh/product/).
@@ -804,7 +804,7 @@ To find out more, check out the demo below and go to our [website](https://platf
 
 <h3 align="center">Help us keep top-notch templates!</h3>
 
-Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks. 
+Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks.
 
 See something that's wrong with this template that needs to be fixed? Something in the documentation unclear or missing? Let us know!
 

--- a/templates/drupal8/files/README.md
+++ b/templates/drupal8/files/README.md
@@ -78,7 +78,7 @@ Drupal is a flexible and extensible PHP-based CMS framework.
 #### Quickstart
 
 
-The quickest way to deploy this template on Platform.sh is by clicking the button below. 
+The quickest way to deploy this template on Platform.sh is by clicking the button below.
 This will automatically create a new project and initialize the repository for you.
 
 <p align="center">
@@ -97,7 +97,7 @@ composer create-project platformsh/drupal8 -s dev
 ```
 
 
-> **Note:**    
+> **Note:**
 >
 > Platform.sh templates prioritize upstream release versions over our own. Despite this, we update template dependencies on a scheduled basis independent of those upstreams. Because of this, template repos do not contain releases. This may change in the future, but until then the `-s dev` flag is necessary to use `composer create-project`.
 
@@ -111,7 +111,7 @@ For all of the other options below, clone this repository first:
 git clone https://github.com/platformsh-templates/drupal8
 ```
 
-If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8/generate) button at the top of this page. 
+If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal8/generate) button at the top of this page.
 
 Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAMESPACE/drupal8.git`.
 
@@ -127,24 +127,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -161,7 +161,7 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -177,17 +177,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -211,24 +211,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -249,24 +249,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -286,7 +286,7 @@ Run through the Drupal installer as normal.  You will not be asked for database 
 
 This section provides instructions for running the `drupal8` template locally, connected to a live database instance on an active Platform.sh environment.
 
-In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally. 
+In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally.
 Each of the options below assume that you have already deployed this template to Platform.sh, as well as the following starting commands:
 
 ```bash
@@ -298,14 +298,14 @@ $ platform environment:branch updates
 <details>
 <summary>Drupal: using ddev</summary><br />
 
-ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information. 
+ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information.
 
 In general, the steps are as follows:
 
 1. [Install ddev](https://ddev.readthedocs.io/en/stable/#installation).
 1. A configuration file has already been provided at `.ddev/providers/platform.yaml`, so you should not need to run `ddev config`.
 1. [Retrieve an API token](https://docs.platform.sh/development/cli/api-tokens.html#get-a-token) for your organization via the management console.
-1. Update your dedev global configuration file to use the token you've just retrieved: 
+1. Update your dedev global configuration file to use the token you've just retrieved:
     ```yaml
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
@@ -319,14 +319,14 @@ In general, the steps are as follows:
     environment: CURRENT_ENVIRONMENT
     application: drupal
     ```
-1. Get the current environment's data with `ddev pull platform`. 
+1. Get the current environment's data with `ddev pull platform`.
 1. When you have finished with your work, run `ddev stop` and `ddev poweroff`.
 
 </details>
 <details>
 <summary>Drupal: using Lando</summary><br />
 
-Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/). 
+Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/).
 
 1. [Install Lando](https://docs.lando.dev/getting-started/installation.html).
 1. Make sure Docker is already running - Lando will attempt to start Docker for you, but it's best to have it running in the background before beginning.
@@ -361,7 +361,7 @@ If you already have code you'd like to migrate, feel free to focus on the steps 
 
 ### Getting started
 
-Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh. 
+Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh.
 If you already have a codebase you are trying to migrate, move onto the next step - [Adding and updating files](#adding-and-updating-files) - and substitute any reference to the default branch `main` with some other branch name.
 
 
@@ -381,7 +381,7 @@ $ git merge --allow-unrelated-histories -X theirs 8.9.20
 
 ### Adding and updating files
 
-A small number of files need to be added to or modified in your repository at this point. 
+A small number of files need to be added to or modified in your repository at this point.
 Some of them explicitly configure how the application is built and deployed on Platform.sh, while others simply modify files you may already have locally, in which case you will need to replicate those changes.
 
 Open the dropdown below to view all of the **Added** and **Updated** files you'll need to reproduce in your migration.
@@ -414,9 +414,9 @@ Open the dropdown below to view all of the **Added** and **Updated** files you'l
 
 ### Dependencies and configuration
 
-Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh. 
-When it is, we do our best to keep these modifications to the minimum necessary. 
-Run the commands below to reproduce the dependencies in this template. 
+Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh.
+When it is, we do our best to keep these modifications to the minimum necessary.
+Run the commands below to reproduce the dependencies in this template.
 
 
 
@@ -425,7 +425,7 @@ $ composer require platformsh/config-reader drush/drush:^10.6 drupal/console dru
 $ composer config allow-plugins.composer/installers true --no-plugins
 $ composer config allow-plugins.drupal/core-composer-scaffold true --no-plugins
 $ composer config allow-plugins.drupal/core-project-message true --no-plugins
-$ composer config allow-plugins.cweagans/composer-patches true --no-plugins 
+$ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ```
 
@@ -433,7 +433,7 @@ $ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ### Deploying to Platform.sh
 
-Your repository now has all of the code it needs in order to deploy to Platform.sh. 
+Your repository now has all of the code it needs in order to deploy to Platform.sh.
 
 
 <details>
@@ -447,24 +447,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -481,7 +481,7 @@ Your repository now has all of the code it needs in order to deploy to Platform.
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -497,17 +497,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -531,24 +531,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -569,24 +569,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -616,12 +616,12 @@ platform sql -e main < database.sql
 <details>
 <summary>Importing files</summary><br/>
 
-You first need to download your files from your current hosting environment. 
-The easiest way is likely with rsync, but consult your old host's documentation. 
+You first need to download your files from your current hosting environment.
+The easiest way is likely with rsync, but consult your old host's documentation.
 
-The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file. 
-Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible. 
-(There is also a `platform mount:download` command you can use to download files later.) 
+The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file.
+Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible.
+(There is also a `platform mount:download` command you can use to download files later.)
 Run the following from your local Git repository root (modifying the `--source` path if needed and setting `BRANCH_NAME` to the branch you are using).
 
 A few examples are listed below, but repeat for all directories that contain data you would like to migrate.
@@ -639,12 +639,12 @@ Note that `rsync` is picky about its trailing slashes, so be sure to include tho
 
 ### Next steps
 
-With your application now deployed on Platform.sh, things get more interesting. 
-Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch. 
+With your application now deployed on Platform.sh, things get more interesting.
+Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch.
 
 The resulting environment is an *exact* copy of production.
-It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services. 
-On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production. 
+It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services.
+On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production.
 
 After that, here are a collection of additional resources you might find interesting as you continue with your migration to Platform.sh:
 
@@ -671,7 +671,7 @@ After the environment has finished its deployment, you can investigate issues th
 platform ssh
 ```
 
-If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well. 
+If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well.
 Once you have connected to the container, [logs](https://docs.platform.sh/development/logs.html#container-logs) are available within `/var/log/` for you to investigate.
 
 </details>
@@ -705,7 +705,7 @@ In the past, Platform.sh templates have overridden this value:
 $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 ```
 
-This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`. 
+This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`.
 
 Now, the setting looks like this in `settings.platformsh.php`:
 
@@ -713,7 +713,7 @@ Now, the setting looks like this in `settings.platformsh.php`:
 $settings['hash_salt'] = empty($settings['hash_salt']) ? $platformsh->projectEntropy : $settings['hash_salt'];
 ```
 
-This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`. 
+This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`.
 If your application code *depends* on an empty value, feel free to comment out that line, or reset again later in that file.
 
 Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platformsh-templates/drupal9/pull/73) for more details on this discussion.
@@ -725,7 +725,7 @@ Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platfo
 
 ### Blackfire.io: creating a Continuous Observability Strategy
 
-This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html). 
+This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html).
 
 * [What is Blackfire?](https://blackfire.io/docs/introduction)
 * [Configuring Blackfire.io on a Platform.sh project](https://docs.platform.sh/integrations/observability/blackfire.html)
@@ -767,7 +767,7 @@ Our key features include:
 
 * **GitOps: Git as the source of truth**
 
-    Every branch becomes a development environment, and nothing can change without a commit. 
+    Every branch becomes a development environment, and nothing can change without a commit.
 
 * **Batteries included: Managed infrastructure**
 
@@ -775,11 +775,11 @@ Our key features include:
 
 * **Instant cloning: Branch, merge, repeat**
 
-    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.  
+    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.
 
 * **FleetOps: Fleet management platform**
 
-    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code. 
+    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code.
 
 
 To find out more, check out the demo below and go to our [website](https://platform.sh/product/).
@@ -798,7 +798,7 @@ To find out more, check out the demo below and go to our [website](https://platf
 
 <h3 align="center">Help us keep top-notch templates!</h3>
 
-Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks. 
+Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks.
 
 See something that's wrong with this template that needs to be fixed? Something in the documentation unclear or missing? Let us know!
 

--- a/templates/drupal9-govcms9/files/README-platformsh.md
+++ b/templates/drupal9-govcms9/files/README-platformsh.md
@@ -126,17 +126,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -176,17 +176,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -210,17 +210,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -248,17 +248,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -445,17 +445,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -495,17 +495,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -529,17 +529,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -567,17 +567,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).

--- a/templates/drupal9-multisite/files/README.md
+++ b/templates/drupal9-multisite/files/README.md
@@ -83,7 +83,7 @@ Drupal is a flexible and extensible PHP-based CMS framework capable of hosting m
 #### Quickstart
 
 
-The quickest way to deploy this template on Platform.sh is by clicking the button below. 
+The quickest way to deploy this template on Platform.sh is by clicking the button below.
 This will automatically create a new project and initialize the repository for you.
 
 <p align="center">
@@ -102,7 +102,7 @@ composer create-project platformsh/drupal9-multisite -s dev
 ```
 
 
-> **Note:**    
+> **Note:**
 >
 > Platform.sh templates prioritize upstream release versions over our own. Despite this, we update template dependencies on a scheduled basis independent of those upstreams. Because of this, template repos do not contain releases. This may change in the future, but until then the `-s dev` flag is necessary to use `composer create-project`.
 
@@ -116,7 +116,7 @@ For all of the other options below, clone this repository first:
 git clone https://github.com/platformsh-templates/drupal9-multisite
 ```
 
-If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal9-multisite/generate) button at the top of this page. 
+If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal9-multisite/generate) button at the top of this page.
 
 Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAMESPACE/drupal9-multisite.git`.
 
@@ -132,24 +132,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -166,7 +166,7 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -182,17 +182,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -216,24 +216,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -254,24 +254,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -290,7 +290,7 @@ Each subsite installs separately. As configured, this project uses a subdomain f
 
 This section provides instructions for running the `drupal9-multisite` template locally, connected to a live database instance on an active Platform.sh environment.
 
-In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally. 
+In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally.
 Each of the options below assume that you have already deployed this template to Platform.sh, as well as the following starting commands:
 
 ```bash
@@ -302,14 +302,14 @@ $ platform environment:branch updates
 <details>
 <summary>Drupal: using ddev</summary><br />
 
-ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information. 
+ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information.
 
 In general, the steps are as follows:
 
 1. [Install ddev](https://ddev.readthedocs.io/en/stable/#installation).
 1. A configuration file has already been provided at `.ddev/providers/platform.yaml`, so you should not need to run `ddev config`.
 1. [Retrieve an API token](https://docs.platform.sh/development/cli/api-tokens.html#get-a-token) for your organization via the management console.
-1. Update your dedev global configuration file to use the token you've just retrieved: 
+1. Update your dedev global configuration file to use the token you've just retrieved:
     ```yaml
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
@@ -323,14 +323,14 @@ In general, the steps are as follows:
     environment: CURRENT_ENVIRONMENT
     application: drupal
     ```
-1. Get the current environment's data with `ddev pull platform`. 
+1. Get the current environment's data with `ddev pull platform`.
 1. When you have finished with your work, run `ddev stop` and `ddev poweroff`.
 
 </details>
 <details>
 <summary>Drupal: using Lando</summary><br />
 
-Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/). 
+Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/).
 
 1. [Install Lando](https://docs.lando.dev/getting-started/installation.html).
 1. Make sure Docker is already running - Lando will attempt to start Docker for you, but it's best to have it running in the background before beginning.
@@ -365,7 +365,7 @@ If you already have code you'd like to migrate, feel free to focus on the steps 
 
 ### Getting started
 
-Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh. 
+Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh.
 If you already have a codebase you are trying to migrate, move onto the next step - [Adding and updating files](#adding-and-updating-files) - and substitute any reference to the default branch `main` with some other branch name.
 
 
@@ -385,7 +385,7 @@ $ git merge --allow-unrelated-histories -X theirs 9.3.9
 
 ### Adding and updating files
 
-A small number of files need to be added to or modified in your repository at this point. 
+A small number of files need to be added to or modified in your repository at this point.
 Some of them explicitly configure how the application is built and deployed on Platform.sh, while others simply modify files you may already have locally, in which case you will need to replicate those changes.
 
 Open the dropdown below to view all of the **Added** and **Updated** files you'll need to reproduce in your migration.
@@ -421,9 +421,9 @@ Open the dropdown below to view all of the **Added** and **Updated** files you'l
 
 ### Dependencies and configuration
 
-Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh. 
-When it is, we do our best to keep these modifications to the minimum necessary. 
-Run the commands below to reproduce the dependencies in this template. 
+Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh.
+When it is, we do our best to keep these modifications to the minimum necessary.
+Run the commands below to reproduce the dependencies in this template.
 
 
 
@@ -432,7 +432,7 @@ $ composer require platformsh/config-reader drush/drush drupal/redis
 $ composer config allow-plugins.composer/installers true --no-plugins
 $ composer config allow-plugins.drupal/core-composer-scaffold true --no-plugins
 $ composer config allow-plugins.drupal/core-project-message true --no-plugins
-$ composer config allow-plugins.cweagans/composer-patches true --no-plugins 
+$ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ```
 
@@ -440,7 +440,7 @@ $ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ### Deploying to Platform.sh
 
-Your repository now has all of the code it needs in order to deploy to Platform.sh. 
+Your repository now has all of the code it needs in order to deploy to Platform.sh.
 
 
 <details>
@@ -454,24 +454,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -488,7 +488,7 @@ Your repository now has all of the code it needs in order to deploy to Platform.
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -504,17 +504,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -538,24 +538,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -576,24 +576,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -623,12 +623,12 @@ platform sql -e main < database.sql
 <details>
 <summary>Importing files</summary><br/>
 
-You first need to download your files from your current hosting environment. 
-The easiest way is likely with rsync, but consult your old host's documentation. 
+You first need to download your files from your current hosting environment.
+The easiest way is likely with rsync, but consult your old host's documentation.
 
-The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file. 
-Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible. 
-(There is also a `platform mount:download` command you can use to download files later.) 
+The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file.
+Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible.
+(There is also a `platform mount:download` command you can use to download files later.)
 Run the following from your local Git repository root (modifying the `--source` path if needed and setting `BRANCH_NAME` to the branch you are using).
 
 A few examples are listed below, but repeat for all directories that contain data you would like to migrate.
@@ -646,12 +646,12 @@ Note that `rsync` is picky about its trailing slashes, so be sure to include tho
 
 ### Next steps
 
-With your application now deployed on Platform.sh, things get more interesting. 
-Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch. 
+With your application now deployed on Platform.sh, things get more interesting.
+Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch.
 
 The resulting environment is an *exact* copy of production.
-It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services. 
-On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production. 
+It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services.
+On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production.
 
 After that, here are a collection of additional resources you might find interesting as you continue with your migration to Platform.sh:
 
@@ -678,7 +678,7 @@ After the environment has finished its deployment, you can investigate issues th
 platform ssh
 ```
 
-If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well. 
+If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well.
 Once you have connected to the container, [logs](https://docs.platform.sh/development/logs.html#container-logs) are available within `/var/log/` for you to investigate.
 
 </details>
@@ -712,7 +712,7 @@ In the past, Platform.sh templates have overridden this value:
 $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 ```
 
-This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`. 
+This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`.
 
 Now, the setting looks like this in `settings.platformsh.php`:
 
@@ -720,7 +720,7 @@ Now, the setting looks like this in `settings.platformsh.php`:
 $settings['hash_salt'] = empty($settings['hash_salt']) ? $platformsh->projectEntropy : $settings['hash_salt'];
 ```
 
-This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`. 
+This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`.
 If your application code *depends* on an empty value, feel free to comment out that line, or reset again later in that file.
 
 Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platformsh-templates/drupal9/pull/73) for more details on this discussion.
@@ -778,7 +778,7 @@ Any Drush command can therefore be used on a specific subsite by using `--uri=`.
 
 ### Blackfire.io: creating a Continuous Observability Strategy
 
-This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html). 
+This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html).
 
 * [What is Blackfire?](https://blackfire.io/docs/introduction)
 * [Configuring Blackfire.io on a Platform.sh project](https://docs.platform.sh/integrations/observability/blackfire.html)
@@ -821,7 +821,7 @@ Our key features include:
 
 * **GitOps: Git as the source of truth**
 
-    Every branch becomes a development environment, and nothing can change without a commit. 
+    Every branch becomes a development environment, and nothing can change without a commit.
 
 * **Batteries included: Managed infrastructure**
 
@@ -829,11 +829,11 @@ Our key features include:
 
 * **Instant cloning: Branch, merge, repeat**
 
-    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.  
+    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.
 
 * **FleetOps: Fleet management platform**
 
-    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code. 
+    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code.
 
 
 To find out more, check out the demo below and go to our [website](https://platform.sh/product/).
@@ -852,7 +852,7 @@ To find out more, check out the demo below and go to our [website](https://platf
 
 <h3 align="center">Help us keep top-notch templates!</h3>
 
-Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks. 
+Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks.
 
 See something that's wrong with this template that needs to be fixed? Something in the documentation unclear or missing? Let us know!
 

--- a/templates/drupal9/files/README.md
+++ b/templates/drupal9/files/README.md
@@ -78,7 +78,7 @@ Drupal is a flexible and extensible PHP-based CMS framework.
 #### Quickstart
 
 
-The quickest way to deploy this template on Platform.sh is by clicking the button below. 
+The quickest way to deploy this template on Platform.sh is by clicking the button below.
 This will automatically create a new project and initialize the repository for you.
 
 <p align="center">
@@ -97,7 +97,7 @@ composer create-project platformsh/drupal9 -s dev
 ```
 
 
-> **Note:**    
+> **Note:**
 >
 > Platform.sh templates prioritize upstream release versions over our own. Despite this, we update template dependencies on a scheduled basis independent of those upstreams. Because of this, template repos do not contain releases. This may change in the future, but until then the `-s dev` flag is necessary to use `composer create-project`.
 
@@ -111,7 +111,7 @@ For all of the other options below, clone this repository first:
 git clone https://github.com/platformsh-templates/drupal9
 ```
 
-If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal9/generate) button at the top of this page. 
+If you're trying to deploy from GitHub, you can generate a copy of this repository first in your own namespace by clicking the [Use this template](https://github.com/platformsh-templates/drupal9/generate) button at the top of this page.
 
 Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAMESPACE/drupal9.git`.
 
@@ -127,24 +127,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -161,7 +161,7 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -177,17 +177,17 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -211,24 +211,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -249,24 +249,24 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -286,7 +286,7 @@ Run through the Drupal installer as normal.  You will not be asked for database 
 
 This section provides instructions for running the `drupal9` template locally, connected to a live database instance on an active Platform.sh environment.
 
-In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally. 
+In all cases for developing with Platform.sh, it's important to develop on an isolated environment - do not connect to data on your production environment when developing locally.
 Each of the options below assume that you have already deployed this template to Platform.sh, as well as the following starting commands:
 
 ```bash
@@ -298,14 +298,14 @@ $ platform environment:branch updates
 <details>
 <summary>Drupal: using ddev</summary><br />
 
-ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information. 
+ddev provides an integration with Platform.sh that makes it simple to develop Drupal locally. Check the [providers documentation](https://ddev.readthedocs.io/en/latest/users/providers/platform/) for the most up-to-date information.
 
 In general, the steps are as follows:
 
 1. [Install ddev](https://ddev.readthedocs.io/en/stable/#installation).
 1. A configuration file has already been provided at `.ddev/providers/platform.yaml`, so you should not need to run `ddev config`.
 1. [Retrieve an API token](https://docs.platform.sh/development/cli/api-tokens.html#get-a-token) for your organization via the management console.
-1. Update your dedev global configuration file to use the token you've just retrieved: 
+1. Update your dedev global configuration file to use the token you've just retrieved:
     ```yaml
     web_environment:
     - PLATFORMSH_CLI_TOKEN=abcdeyourtoken`
@@ -319,14 +319,14 @@ In general, the steps are as follows:
     environment: CURRENT_ENVIRONMENT
     application: drupal
     ```
-1. Get the current environment's data with `ddev pull platform`. 
+1. Get the current environment's data with `ddev pull platform`.
 1. When you have finished with your work, run `ddev stop` and `ddev poweroff`.
 
 </details>
 <details>
 <summary>Drupal: using Lando</summary><br />
 
-Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/). 
+Lando supports PHP applications [configured to run on Platform.sh](https://docs.platform.sh/development/local/lando.html), and pulls from the same container registry Platform.sh uses on your remote environments during your local builds through its own [recipe and plugin](https://docs.lando.dev/platformsh/).
 
 1. [Install Lando](https://docs.lando.dev/getting-started/installation.html).
 1. Make sure Docker is already running - Lando will attempt to start Docker for you, but it's best to have it running in the background before beginning.
@@ -361,7 +361,7 @@ If you already have code you'd like to migrate, feel free to focus on the steps 
 
 ### Getting started
 
-Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh. 
+Assuming that your starting point is no local code, the steps below will setup a starting repository we can begin to make changes to to rebuild this template and migrate to Platform.sh.
 If you already have a codebase you are trying to migrate, move onto the next step - [Adding and updating files](#adding-and-updating-files) - and substitute any reference to the default branch `main` with some other branch name.
 
 
@@ -381,7 +381,7 @@ $ git merge --allow-unrelated-histories -X theirs 9.3.9
 
 ### Adding and updating files
 
-A small number of files need to be added to or modified in your repository at this point. 
+A small number of files need to be added to or modified in your repository at this point.
 Some of them explicitly configure how the application is built and deployed on Platform.sh, while others simply modify files you may already have locally, in which case you will need to replicate those changes.
 
 Open the dropdown below to view all of the **Added** and **Updated** files you'll need to reproduce in your migration.
@@ -413,9 +413,9 @@ Open the dropdown below to view all of the **Added** and **Updated** files you'l
 
 ### Dependencies and configuration
 
-Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh. 
-When it is, we do our best to keep these modifications to the minimum necessary. 
-Run the commands below to reproduce the dependencies in this template. 
+Sometimes it is necessary to install additional dependencies to and modify the configuration of an upstream project to deploy on Platform.sh.
+When it is, we do our best to keep these modifications to the minimum necessary.
+Run the commands below to reproduce the dependencies in this template.
 
 
 
@@ -424,7 +424,7 @@ $ composer require platformsh/config-reader drush/drush drupal/redis
 $ composer config allow-plugins.composer/installers true --no-plugins
 $ composer config allow-plugins.drupal/core-composer-scaffold true --no-plugins
 $ composer config allow-plugins.drupal/core-project-message true --no-plugins
-$ composer config allow-plugins.cweagans/composer-patches true --no-plugins 
+$ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ```
 
@@ -432,7 +432,7 @@ $ composer config allow-plugins.cweagans/composer-patches true --no-plugins
 
 ### Deploying to Platform.sh
 
-Your repository now has all of the code it needs in order to deploy to Platform.sh. 
+Your repository now has all of the code it needs in order to deploy to Platform.sh.
 
 
 <details>
@@ -446,24 +446,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Set the project remote
 
-   Find your `PROJECT_ID` by running the command `platform project:list` 
+   Find your `PROJECT_ID` by running the command `platform project:list`
 
    ```bash
    +---------------+------------------------------------+------------------+---------------------------------+
@@ -480,7 +480,7 @@ Your repository now has all of the code it needs in order to deploy to Platform.
    ```bash
    git push platform DEFAULT_BRANCH
    ```
-   
+
 <!-- <br/>
 </blockquote> -->
 </details>
@@ -496,17 +496,17 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
@@ -530,24 +530,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on GitLab, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -568,24 +568,24 @@ Your repository now has all of the code it needs in order to deploy to Platform.
 
 1. Install the Platform.sh CLI
 
-   #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
    ```bash
-   curl -sS https://platform.sh/cli/installer | php
+   $ brew install platformsh/tap/platformsh-cli
    ```
 
-   #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
    ```bash
-   curl -f https://platform.sh/cli/installer -o cli-installer.php
-   php cli-installer.php
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
    ```
 
    You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
 1. Create the repository
 
-   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch. 
+   Create a new repository on Bitbucket, set it as a new remote for your local copy, and push to the default branch.
 
 1. Setup the integration:
 
@@ -615,12 +615,12 @@ platform sql -e main < database.sql
 <details>
 <summary>Importing files</summary><br/>
 
-You first need to download your files from your current hosting environment. 
-The easiest way is likely with rsync, but consult your old host's documentation. 
+You first need to download your files from your current hosting environment.
+The easiest way is likely with rsync, but consult your old host's documentation.
 
-The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file. 
-Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible. 
-(There is also a `platform mount:download` command you can use to download files later.) 
+The `platform mount:upload` command provides a straightforward way to upload an entire directory to your site at once to a `mount` defined in a `.platform.app.yaml` file.
+Under the hood, it uses an SSH tunnel and rsync, so it is as efficient as possible.
+(There is also a `platform mount:download` command you can use to download files later.)
 Run the following from your local Git repository root (modifying the `--source` path if needed and setting `BRANCH_NAME` to the branch you are using).
 
 A few examples are listed below, but repeat for all directories that contain data you would like to migrate.
@@ -638,12 +638,12 @@ Note that `rsync` is picky about its trailing slashes, so be sure to include tho
 
 ### Next steps
 
-With your application now deployed on Platform.sh, things get more interesting. 
-Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch. 
+With your application now deployed on Platform.sh, things get more interesting.
+Run the command `platform environment:branch new-feature` for your project, or open a trivial pull request off of your current branch.
 
 The resulting environment is an *exact* copy of production.
-It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services. 
-On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production. 
+It contains identical infrastructure to what's been defined in your configuration files, and even includes data copied from your production environment in its services.
+On this isolated environment, you're free to make any changes to your application you need to, and really test how they will behave on production.
 
 After that, here are a collection of additional resources you might find interesting as you continue with your migration to Platform.sh:
 
@@ -670,7 +670,7 @@ After the environment has finished its deployment, you can investigate issues th
 platform ssh
 ```
 
-If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well. 
+If you are running the command outside of a local copy of the project, you will need to include the `-p` (project) and/or `-e` (environment) flags as well.
 Once you have connected to the container, [logs](https://docs.platform.sh/development/logs.html#container-logs) are available within `/var/log/` for you to investigate.
 
 </details>
@@ -704,7 +704,7 @@ In the past, Platform.sh templates have overridden this value:
 $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 ```
 
-This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`. 
+This setting was insufficient to cover some user configurations - such as those cases when an application depends on a `Null` value for `hash_salt`.
 
 Now, the setting looks like this in `settings.platformsh.php`:
 
@@ -712,7 +712,7 @@ Now, the setting looks like this in `settings.platformsh.php`:
 $settings['hash_salt'] = empty($settings['hash_salt']) ? $platformsh->projectEntropy : $settings['hash_salt'];
 ```
 
-This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`. 
+This change sets `hash_salt` to the built-in environment variable `PLATFORM_PROJECT_ENTROPY` value if the project contains the default settings OR `Null`.
 If your application code *depends* on an empty value, feel free to comment out that line, or reset again later in that file.
 
 Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platformsh-templates/drupal9/pull/73) for more details on this discussion.
@@ -724,7 +724,7 @@ Feel free to visit [`platformsh-templates/drupal9#73`](https://github.com/platfo
 
 ### Blackfire.io: creating a Continuous Observability Strategy
 
-This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html). 
+This template includes a starting [`.blackfire.yml`](.blackfire.yml) file that can be used to enable [Application Performance Monitoring](https://blackfire.io/docs/monitoring-cookbooks/index), [Profiling](https://blackfire.io/docs/profiling-cookbooks/index), [Builds](https://blackfire.io/docs/builds-cookbooks/index) and [Performance Testing](https://blackfire.io/docs/testing-cookbooks/index) on your project. Platform.sh comes with Blackfire pre-installed on application containers, and [setting up requires minimal configuration](https://docs.platform.sh/integrations/observability/blackfire.html).
 
 * [What is Blackfire?](https://blackfire.io/docs/introduction)
 * [Configuring Blackfire.io on a Platform.sh project](https://docs.platform.sh/integrations/observability/blackfire.html)
@@ -766,7 +766,7 @@ Our key features include:
 
 * **GitOps: Git as the source of truth**
 
-    Every branch becomes a development environment, and nothing can change without a commit. 
+    Every branch becomes a development environment, and nothing can change without a commit.
 
 * **Batteries included: Managed infrastructure**
 
@@ -774,11 +774,11 @@ Our key features include:
 
 * **Instant cloning: Branch, merge, repeat**
 
-    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.  
+    [Reusable builds](https://docs.platform.sh/overview/build-deploy.html) and automatically inherited production data provide true staging environments - experiment in isolation, test, then destroy or merge.
 
 * **FleetOps: Fleet management platform**
 
-    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code. 
+    Leverage our public API along with custom tools like [Source Operations](https://docs.platform.sh/configuration/app/source-operations.html) and [Activity Scripts](https://docs.platform.sh/integrations/activity.html) to [manage thousands of applications](https://youtu.be/MILHG9OqhmE) - their dependency updates, fresh content, and upstream code.
 
 
 To find out more, check out the demo below and go to our [website](https://platform.sh/product/).
@@ -797,7 +797,7 @@ To find out more, check out the demo below and go to our [website](https://platf
 
 <h3 align="center">Help us keep top-notch templates!</h3>
 
-Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks. 
+Every one of our templates is open source, and they're important resources for users trying to deploy to Platform.sh for the first time or better understand the platform. They act as getting started guides, but also contain a number of helpful tips and best practices when working with certain languages and frameworks.
 
 See something that's wrong with this template that needs to be fixed? Something in the documentation unclear or missing? Let us know!
 

--- a/templates/flask/files/README.md
+++ b/templates/flask/files/README.md
@@ -109,18 +109,18 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-    #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
-    ```bash
-    curl -sS https://platform.sh/cli/installer | php
-    ```
+   ```bash
+   $ brew install platformsh/tap/platformsh-cli
+   ```
 
-    #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
-    ```bash
-    curl -f https://platform.sh/cli/installer -o cli-installer.php
-    php cli-installer.php
-    ```
+   ```bash
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
+   ```
 
     You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
@@ -159,18 +159,18 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-    #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
-    ```bash
-    curl -sS https://platform.sh/cli/installer | php
-    ```
+   ```bash
+   $ brew install platformsh/tap/platformsh-cli
+   ```
 
-    #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
-    ```bash
-    curl -f https://platform.sh/cli/installer -o cli-installer.php
-    php cli-installer.php
-    ```
+   ```bash
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
+   ```
 
     You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
@@ -193,18 +193,18 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-    #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
-    ```bash
-    curl -sS https://platform.sh/cli/installer | php
-    ```
+   ```bash
+   $ brew install platformsh/tap/platformsh-cli
+   ```
 
-    #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
-    ```bash
-    curl -f https://platform.sh/cli/installer -o cli-installer.php
-    php cli-installer.php
-    ```
+   ```bash
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
+   ```
 
     You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 
@@ -231,18 +231,18 @@ Then you can clone a copy of it locally with `git clone git@github.com:YOUR_NAME
 
 1. Install the Platform.sh CLI
 
-    #### Linux/OSX
+   #### Linux/OSX (using [Homebrew](https://brew.sh/))
 
-    ```bash
-    curl -sS https://platform.sh/cli/installer | php
-    ```
+   ```bash
+   $ brew install platformsh/tap/platformsh-cli
+   ```
 
-    #### Windows
+   #### Windows (using [Scoop](https://scoop.sh/))
 
-    ```bash
-    curl -f https://platform.sh/cli/installer -o cli-installer.php
-    php cli-installer.php
-    ```
+   ```bash
+    $ scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git
+    $ scoop install platform
+   ```
 
     You can verify the installation by logging in (`platformsh login`) and listing your projects (`platform project:list`).
 


### PR DESCRIPTION
Updates all mentions of the Platform.sh CLI installation in various templates' README.md files to the new installation instructions. Closes #697 