### PR TITLE
Handle default branches & testing orgs

### DIFF
--- a/project/__init__.py
+++ b/project/__init__.py
@@ -22,6 +22,7 @@ class BaseProject(object):
     '''
 
     default_branch = "master"
+    template_org = "platformsh-templates"
 
     # A dictionary of conditional commands to run for package updaters.
     # The key is a file name. If that file exists, then its value will be run in the
@@ -113,8 +114,8 @@ class BaseProject(object):
             name = self.github_name
         else:
             name = self.name.replace('_', '-')
-        return ['git clone git@github.com:platformsh-templates/{0}.git {1}'.format(
-            name, self.builddir)
+        return ['git clone git@github.com:{2}/{0}.git {1}'.format(
+            name, self.builddir, self.template_org)
         ]
 
     @property

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -21,6 +21,8 @@ class BaseProject(object):
     to override.
     '''
 
+    default_branch = "master"
+
     # A dictionary of conditional commands to run for package updaters.
     # The key is a file name. If that file exists, then its value will be run in the
     # project build directory to update the corresponding lock file.
@@ -118,7 +120,7 @@ class BaseProject(object):
     @property
     def update(self):
         actions = [
-            'cd {0} && git checkout master && git pull --prune'.format(self.builddir)
+            'cd {0} && git checkout {1} && git pull --prune'.format(self.builddir, self.default_branch)
         ]
 
         actions.extend(self.package_update_actions())
@@ -166,8 +168,8 @@ class BaseProject(object):
     @property
     def branch(self):
         return [
-            'cd {0} && if git rev-parse --verify --quiet {1}; then git checkout master && git branch -D {1}; fi;'.format(
-                self.builddir, self.updateBranch),
+            'cd {0} && if git rev-parse --verify --quiet {1}; then git checkout {2} && git branch -D {1}; fi;'.format(
+                self.builddir, self.updateBranch, self.default_branch),
             'cd {0} && git checkout -b {1}'.format(self.builddir, self.updateBranch),
             # git commit exits with 1 if there's nothing to update, so the diff-index check will
             # short circuit the command if there's nothing to update with an exit code of 0.
@@ -178,8 +180,8 @@ class BaseProject(object):
     @property
     def push(self):
         return [
-            'cd {0} && if [ `git rev-parse {1}` != `git rev-parse master` ] ; then git checkout {1} && git push --force -u origin {1}; fi'.format(
-                self.builddir, self.updateBranch)
+            'cd {0} && if [ `git rev-parse {1}` != `git rev-parse {2}` ] ; then git checkout {1} && git push --force -u origin {1}; fi'.format(
+                self.builddir, self.updateBranch, self.default_branch)
         ]
 
     def package_update_actions(self):

--- a/project/drupal.py
+++ b/project/drupal.py
@@ -393,7 +393,12 @@ class Drupal9_govcms9(RemoteProject):
 class Drupal10(RemoteProject):
     major_version = "10.0.0-rc1"
     remote = 'https://github.com/drupal/recommended-project.git'
+
     default_branch = "main"
+
+    # Example for pushing to a fork
+    # default_branch = "master"
+    # template_org = "Mupsi"
 
     def package_update_actions(self):
         actions = super(Drupal10, self).package_update_actions()

--- a/project/drupal.py
+++ b/project/drupal.py
@@ -393,6 +393,7 @@ class Drupal9_govcms9(RemoteProject):
 class Drupal10(RemoteProject):
     major_version = "10.0.0-rc1"
     remote = 'https://github.com/drupal/recommended-project.git'
+    default_branch = "main"
 
     def package_update_actions(self):
         actions = super(Drupal10, self).package_update_actions()

--- a/project/remote.py
+++ b/project/remote.py
@@ -28,7 +28,7 @@ class RemoteProject(BaseProject):
     @property
     def update(self):
         actions = [
-            'cd {0} && git checkout master'.format(self.builddir),
+            'cd {0} && git checkout {1}'.format(self.builddir, self.default_branch),
             'cd {0} && git fetch --all --depth=2'.format(self.builddir),
             'cd {0} && git fetch --all --tags'.format(self.builddir),
             # Remove working directory files when updating from upstream, so that deletions get picked up.


### PR DESCRIPTION
Pushed to Drupal 10 here https://github.com/platformsh-templates/drupal10/pull/1

Allows for:
- a target template repo to have a configurable default branch, where `master` is the default setting.
- a target template repo can exist in any organization, where `platformsh-templates` is the default setting.