### PR TITLE
WIP: Updates/703 php74 php81 part2

### DIFF
--- a/templates/backdrop/files/.platform.app.yaml
+++ b/templates/backdrop/files/.platform.app.yaml
@@ -4,7 +4,7 @@
 name: 'app'
 
 # The type key specifies the language and version for your application.
-type: 'php:7.4'
+type: 'php:8.1'
 
 # On PHP, there are multiple build flavors available. Pretty much everyone
 # except Drupal 7 and Backdrop users will want the composer flavor.

--- a/templates/drupal8-multisite/files/.platform.app.yaml
+++ b/templates/drupal8-multisite/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: 'drupal'
 
 # The runtime the application uses.
-type: 'php:7.4'
+type: 'php:8.1'
 
 dependencies:
     php:

--- a/templates/drupal8-opigno/files/.platform.app.yaml
+++ b/templates/drupal8-opigno/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: 'drupal'
 
 # The runtime the application uses.
-type: 'php:7.4'
+type: 'php:8.1'
 
 dependencies:
     php:

--- a/templates/drupal8/files/.platform.app.yaml
+++ b/templates/drupal8/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: 'drupal'
 
 # The runtime the application uses.
-type: 'php:7.4'
+type: 'php:8.1'
 
 dependencies:
     php:

--- a/templates/gatsby-drupal/files/drupal/.platform.app.yaml
+++ b/templates/gatsby-drupal/files/drupal/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: 'drupal'
 
 # The runtime the application uses.
-type: 'php:7.4'
+type: 'php:8.1'
 
 dependencies:
     php:

--- a/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
+++ b/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: wordpress
 
 # The runtime the application uses.
-type: "php:7.4"
+type: 'php:8.1'
 
 # Configuration of the build of the application.
 build:

--- a/templates/nextcloud/files/.platform.app.yaml
+++ b/templates/nextcloud/files/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: app
 
 # The runtime the application uses.
-type: "php:7.4"
+type: 'php:8.1'
 
 runtime:
     extensions:

--- a/templates/nextcloud/files/.platform.app.yaml
+++ b/templates/nextcloud/files/.platform.app.yaml
@@ -109,8 +109,10 @@ crons:
     # Run NextClouds's cron tasks every 5 minutes.
     cron:
         spec: '*/5 * * * *'
-        commands: 'cd src ; php cron.php'
+        commands:
+            start: 'cd src ; php cron.php'
     preview:
         spec: '*/10 * * * *'
-        commands: './occ preview:pre-generate'
+        commands:
+            start: './occ preview:pre-generate'
 

--- a/templates/pimcore/files/.platform.app.yaml
+++ b/templates/pimcore/files/.platform.app.yaml
@@ -104,7 +104,8 @@ hooks:
 crons:
     pimcore_cron:
         spec: "*/5 * * * *"
-        commands: "bin/console maintenance"
+        commands:
+            start: "bin/console maintenance"
 
 source:
   operations:

--- a/templates/pimcore/files/.platform.app.yaml
+++ b/templates/pimcore/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: php:7.4
+type: 'php:8.1'
 
 # The relationships of the application with services or other applications.
 #

--- a/templates/typo3/files/.platform.app.yaml
+++ b/templates/typo3/files/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: php:7.4
+type: 'php:8.1'
 
 dependencies:
     php:

--- a/templates/typo3/files/.platform.app.yaml
+++ b/templates/typo3/files/.platform.app.yaml
@@ -211,7 +211,8 @@ crons:
      # Run TYPO3's Scheduler tasks every 5 minutes.
     typo3:
         spec: "*/5 * * * *"
-        commands: "vendor/bin/typo3 scheduler:run"
+        commands:
+            start: "vendor/bin/typo3 scheduler:run"
 
 source:
   operations:

--- a/templates/wordpress-composer/files/.platform.app.yaml
+++ b/templates/wordpress-composer/files/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: app
 
 # The runtime the application uses.
-type: "php:7.4"
+type: 'php:8.1'
 
 # Configuration of the build of the application.
 build:


### PR DESCRIPTION
Updates the remaining PHP7.4 templates to PHP8.1, part 2 and conclusion of #703. These all fail in their composer update step during the build OR the PR fails 

**Fail during composer update**
* ~~Drupal8 Multisite~~ - see below
* ~~Drupal8 Opigno~~ - see below
* ~~Drupal8~~ - see below
* Pimcore

**Composer update succeeds but environment builds fail**
* [Nextcloud](https://github.com/platformsh-templates/nextcloud/pull/21)
* [Typo3](https://github.com/platformsh-templates/typo3/pull/31)

**Regression introduced from template builder update**
* Drupal Gatsby - I end up with both a `drupal` directory AND an `api` directory in the template builder build.