### PR TITLE
remove build flavor in favor of build hook

### DIFF
--- a/templates/drupal9-govcms9/files/.platform.app.yaml
+++ b/templates/drupal9-govcms9/files/.platform.app.yaml
@@ -66,7 +66,7 @@ mounts:
 
 # Configuration of the build of this application.
 build:
-    flavor: composer
+    flavor: none
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
@@ -78,6 +78,8 @@ hooks:
     # Code cannot be modified at this point but the database is available.
     # The site is not accepting requests while this script runs so keep it
     # fast.
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
     deploy: |
         set -e
         php ./drush/platformsh_generate_drush_yml.php

--- a/templates/drupal9-multisite/files/.platform.app.yaml
+++ b/templates/drupal9-multisite/files/.platform.app.yaml
@@ -70,7 +70,7 @@ mounts:
 # Configuration of the build of this application.
 build:
     # Automatically run `composer install` on every build.
-    flavor: composer
+    flavor: none
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
@@ -82,6 +82,8 @@ hooks:
     # Code cannot be modified at this point but the database is available.
     # The site is not accepting requests while this script runs so keep it
     # fast.
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
     deploy: |
         set -e
         php ./drush/platformsh_generate_drush_yml.php

--- a/templates/drupal9/files/.platform.app.yaml
+++ b/templates/drupal9/files/.platform.app.yaml
@@ -66,7 +66,7 @@ mounts:
 
 # Configuration of the build of this application.
 build:
-    flavor: composer
+    flavor: none
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
@@ -80,6 +80,8 @@ hooks:
     # fast.
     deploy: |
         set -e
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
         php ./drush/platformsh_generate_drush_yml.php
         cd web
         # if drupal is installed, will call the following drush commands:
@@ -148,7 +150,7 @@ crons:
     # Run Drupal's cron tasks every 19 minutes.
     drupal:
         spec: '*/19 * * * *'
-        commands: 
+        commands:
             start: 'cd web ; drush core-cron'
 
 source:

--- a/templates/gatsby-drupal/files/drupal/.platform.app.yaml
+++ b/templates/gatsby-drupal/files/drupal/.platform.app.yaml
@@ -49,7 +49,7 @@ mounts:
 
 # Configuration of the build of this application.
 build:
-    flavor: composer
+    flavor: none
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
@@ -58,6 +58,8 @@ hooks:
         set -e
         bash install-redis.sh 4.3.0
     # The deploy hook runs after your application has been deployed and started.
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
     deploy: |
         set -e
         php ./drush/platformsh_generate_drush_yml.php

--- a/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
+++ b/templates/gatsby-wordpress/files/wordpress/.platform.app.yaml
@@ -9,7 +9,7 @@ type: "php:7.4"
 
 # Configuration of the build of the application.
 build:
-    flavor: composer
+    flavor: none
 
 dependencies:
     php:
@@ -65,3 +65,11 @@ mounts:
     "wordpress/wp-content/uploads":
         source: local
         source_path: "uploads"
+
+hooks:
+    build: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader

--- a/templates/magento2ce/files/.platform.app.yaml
+++ b/templates/magento2ce/files/.platform.app.yaml
@@ -19,7 +19,7 @@ runtime:
 
 # Configuration of the build of this application.
 build:
-    flavor: composer
+    flavor: none
 
 dependencies:
     php:
@@ -58,6 +58,8 @@ mounts:
 hooks:
   build: |
     set -e
+    # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+    composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
     php ./vendor/bin/ece-tools build:generate
     php ./vendor/bin/ece-tools build:transfer
   deploy: |

--- a/templates/sylius/files/.platform.app.yaml
+++ b/templates/sylius/files/.platform.app.yaml
@@ -1,7 +1,7 @@
 name: app
 type: php:8.1
 build:
-    flavor: composer
+    flavor: none
 
 variables:
     env:
@@ -13,6 +13,8 @@ variables:
 hooks:
     build: |
         set -e
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
         # Install the node version specified in the .nvmrc file
         n auto
         # Reset the location hash to recognize the newly installed version

--- a/templates/typo3/files/.platform.app.yaml
+++ b/templates/typo3/files/.platform.app.yaml
@@ -22,7 +22,7 @@ runtime:
 # composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
 # if composer.json is detected.
 build:
-    flavor: composer
+    flavor: none
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed
@@ -122,6 +122,8 @@ hooks:
     build: |
         # Exit hook immediately if a command exits with a non-zero status.
         set -e
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
 
         # Start the installation with no interaction or extension setup, using `SetupConfiguration.yaml`.
         if [ ! -f var/platformsh.installed ]; then

--- a/templates/wordpress-bedrock/files/.platform.app.yaml
+++ b/templates/wordpress-bedrock/files/.platform.app.yaml
@@ -9,7 +9,7 @@ type: "php:8.1"
 
 # Configuration of the build of the application.
 build:
-    flavor: composer
+    flavor: none
 
 dependencies:
     php:
@@ -70,6 +70,14 @@ mounts:
     "web/app/uploads":
         source: local
         source_path: "uploads"
+
+hooks:
+    build: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
 
 source:
   operations:

--- a/templates/wordpress-composer/files/.platform.app.yaml
+++ b/templates/wordpress-composer/files/.platform.app.yaml
@@ -9,7 +9,7 @@ type: "php:7.4"
 
 # Configuration of the build of the application.
 build:
-    flavor: composer
+    flavor: none
 
 dependencies:
     php:
@@ -19,6 +19,9 @@ dependencies:
 hooks:
     build: |
         set -e
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
+
         # Copy manually-provided plugins into the plugins directory.
         # This allows manually-provided and composer-provided plugins to coexist.
         rsync -a plugins/* wordpress/wp-content/plugins/

--- a/templates/wordpress-woocommerce/files/.platform.app.yaml
+++ b/templates/wordpress-woocommerce/files/.platform.app.yaml
@@ -14,7 +14,7 @@ dependencies:
 
 # Configuration of the build of the application.
 build:
-    flavor: composer
+    flavor: none
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed
@@ -73,6 +73,14 @@ mounts:
     "web/wp/wp-content/uploads":
         source: local
         source_path: "uploads"
+
+hooks:
+    build: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+        # @see https://docs.platform.sh/languages/php.html#build-flavor adding `--no-dev`
+        composer install --no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader
 
 source:
   operations:


### PR DESCRIPTION
See #707 
Changes `build:flavor:composer` to `build:flavor: none` and places `composer install` into the build hook with the following options:
`--no-dev --no-progress --no-ansi --no-interaction --prefer-dist --optimize-autoloader`

From #707 , the only thing not included are changes to akeneo and pimcore. 