### PR TITLE
order of platformify cmds in WP Bedrock

### DIFF
--- a/project/wordpress.py
+++ b/project/wordpress.py
@@ -121,7 +121,9 @@ class Wordpress_woocommerce(WordPressComposerBase):
         def wp_modify_composer(composer):
             return super(Wordpress_woocommerce, self).wp_modify_composer(composer, self.unPinDependencies)
 
-        return super(Wordpress_woocommerce, self).platformify + [
+        return [
+            'cd {0} && rm -rf .circleci && rm -rf .github'.format(self.builddir),
+        ] + super(Wordpress_woocommerce, self).platformify + [
             (self.modify_composer, [wp_modify_composer]),
             'cd {0} && rm -rf .circleci && rm -rf .github'.format(self.builddir),
             'cd {0} && composer require wpackagist-plugin/woocommerce wpackagist-plugin/jetpack'.format(

--- a/project/wordpress.py
+++ b/project/wordpress.py
@@ -97,9 +97,10 @@ class Wordpress_bedrock(WordPressComposerBase):
         def wp_modify_composer(composer):
             return super(Wordpress_bedrock, self).wp_modify_composer(composer, self.unPinDependencies)
 
-        return super(Wordpress_bedrock, self).platformify + [
-            (self.modify_composer, [wp_modify_composer]),
+        return [
             'cd {0} && rm -rf .circleci && rm -rf .github'.format(self.builddir),
+        ] + super(Wordpress_bedrock, self).platformify + [
+            (self.modify_composer, [wp_modify_composer]),
             'cd {0} && composer require platformsh/config-reader wp-cli/wp-cli-bundle psy/psysh'.format(
                 self.builddir) + self.composer_defaults(),
             'cd {0} && composer update'.format(self.builddir),

--- a/templates/wordpress-bedrock/files/README.md
+++ b/templates/wordpress-bedrock/files/README.md
@@ -12,7 +12,7 @@ WordPress is a blogging and lightweight CMS written in PHP, and Bedrock is a Com
 
 ## Features
 
-* PHP 7.4
+* PHP 8.1
 * MariaDB 10.4
 * Automatic TLS certificates
 * Composer-based build


### PR DESCRIPTION
changes the order of commands so that the deletion of the .github + .circleci directories from the *upstream* occurs before we add in our .github directory

updates readme for wordpress-bedrock from php7.4 --> php8.1 (this was changed in the template directly, but then wiped out from the template-builder)

Closes #765 
