### PR TITLE
Add issues-to-project action

### DIFF
--- a/project-issues.yaml
+++ b/project-issues.yaml
@@ -1,0 +1,16 @@
+name: Add issues to template-builder project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.1
+        with:
+          project-url: https://github.com/orgs/platformsh/projects/9
+          github-token: ${{ secrets.DEVREL_TOKEN }}


### PR DESCRIPTION
Adds issues to template-builder project when opened https://github.com/marketplace/actions/add-to-github-projects