### PR TITLE
drupal10: don't require script to be executable

### DIFF
--- a/templates/drupal10/files/.platform.app.yaml
+++ b/templates/drupal10/files/.platform.app.yaml
@@ -86,7 +86,7 @@ hooks:
         #   - `updatedb`
         #   - and if config files are present, `config-import`
         cd web
-        $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
+        bash $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
 
 # The configuration of app when it is exposed to the web.
 web:


### PR DESCRIPTION
It's awkward to call scripts like this inside templates, as customers may have copied the files without copying the permissions.