### PR TITLE
Use reusable workflows

### DIFF
--- a/common/sourceop-auto-update/.github/workflows/autopr.yaml
+++ b/common/sourceop-auto-update/.github/workflows/autopr.yaml
@@ -1,3 +1,12 @@
+########################################################################################################################
+##                                                                                                                    ##
+## This github workflow file is part of the Platform.sh process of updating and maintaining our collection of         ##
+## templates. For more information see https://github.com/platformsh-templates/ghrw-templates                         ##
+## and https://github.com/search?q=topic%3Agithub-action+org%3Aplatformsh                                             ##
+##                                                                                                                    ##
+##                                       YOU CAN SAFELY DELETE THIS FILE                                              ##
+##                                                                                                                    ##
+########################################################################################################################
 name: Trigger Auto PR on push to update branch
 on:
   push:
@@ -9,21 +18,6 @@ env:
   PLATFORMSH_CLI_TOKEN: ${{ secrets.TEMPLATES_CLI_TOKEN }}
 
 jobs:
-  create-auto-pr:
-    name: "Creates an auto merging PR when the branch is updated"
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'platformsh-templates' }}
-    steps:
-      - name: 'Prep the repo for autoPR'
-        id: prepautopr
-        uses: platformsh/gha-prep-for-autopr@main
-        with:
-          github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-
-      - name: 'Create & merge PR'
-        id: create-merge-pr
-        uses: platformsh/gha-create-autopr@main
-        with:
-          github-token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-          trigger-source: 'auto push'
-          default-branch: ${{ steps.prepautopr.outputs.default-branch }}
+  run-reusable-autopr:
+    uses: platformsh-templates/ghrw-templates/.github/workflows/autopr.yaml@main
+    secrets: inherit

--- a/common/sourceop-auto-update/.github/workflows/last-updated.yaml
+++ b/common/sourceop-auto-update/.github/workflows/last-updated.yaml
@@ -1,3 +1,12 @@
+########################################################################################################################
+##                                                                                                                    ##
+## This github workflow file is part of the Platform.sh process of updating and maintaining our collection of         ##
+## templates. For more information see https://github.com/platformsh-templates/ghrw-templates                         ##
+## and https://github.com/search?q=topic%3Agithub-action+org%3Aplatformsh                                             ##
+##                                                                                                                    ##
+##                                       YOU CAN SAFELY DELETE THIS FILE                                              ##
+##                                                                                                                    ##
+########################################################################################################################
 name: Update last.updated
 on:
   push:
@@ -5,62 +14,7 @@ on:
       - main
       - master
 
-env:
-  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-  GH_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-
 jobs:
-  update-last-updated-file:
-    name: "Updates the last.updated file with the current date"
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'platformsh-templates' && github.event.commits[0].author.name != 'GitHub Action' }}
-    steps:
-      - name: 'get repo'
-        id: get-repo
-        uses: actions/checkout@v3
-        with:
-          token: ${{secrets.TEMPLATES_GITHUB_TOKEN }}
-
-      - name: 'set git config'
-        shell: bash
-        run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
-
-      - name: 'check for enforce admins'
-        id: 'check-for-enforce'
-        shell: bash
-        run: |
-          enforceAdmins=$(gh api "/repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/enforce_admins" --jq '.enabled')
-          echo "::notice is enforce admins enabled? ${enforceAdmins}"
-          echo "enforce_admin=${enforceAdmins}" >> $GITHUB_OUTPUT
-
-      - name: 'disable enforce admins'
-        id: 'disable-force-admins'
-        if: ${{ 'true' == steps.check-for-enforce.outputs.enforce_admin }}
-        shell: bash
-        run: |
-          echo "::notice::Enforce Admins is enabled. Temporarily disabling..."
-          gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/enforce_admins" --silent \
-               && echo "::notice::Enforce admins disabled" \
-               || echo "::error::Disabling enforce admin failed"
-
-      - name: 'update last.updated'
-        id: last-updated
-        shell: bash
-        run: |
-          date > ./.platform/last.updated
-          git add ./.platform/last.updated
-          git commit -m "auto-updates version, post merge"
-          git push origin "${DEFAULT_BRANCH}"
-
-      - name: "Re-enable enforce admins"
-        id: re-enable-enforce-admin
-        if: ${{ 'true' == steps.check-for-enforce.outputs.enforce_admin }}
-        shell: bash
-        run: |
-          gh api --method POST \
-          -H "Accept: application/vnd.github+json" \
-          "/repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/enforce_admins" --silent \
-          && echo "::notice::Successfully re-enabled enforce admin" \
-          || echo "::error::Re-enabling enforce admins failed."
+  run-reusable-last-update:
+    uses: platformsh-templates/ghrw-templates/.github/workflows/last-updated.yaml@main
+    secrets: inherit

--- a/common/sourceop-auto-update/.github/workflows/sourceops.yaml
+++ b/common/sourceop-auto-update/.github/workflows/sourceops.yaml
@@ -1,23 +1,20 @@
+########################################################################################################################
+##                                                                                                                    ##
+## This github workflow file is part of the Platform.sh process of updating and maintaining our collection of         ##
+## templates. For more information see https://github.com/platformsh-templates/ghrw-templates                         ##
+## and https://github.com/search?q=topic%3Agithub-action+org%3Aplatformsh                                             ##
+##                                                                                                                    ##
+##                                       YOU CAN SAFELY DELETE THIS FILE                                              ##
+##                                                                                                                    ##
+########################################################################################################################
 name: Trigger Source Operations on a Schedule
 on:
   schedule:
     # Run at 00:15 every day
-    - cron: '15 0 * * *'
+    - cron: '15 */19 * * *'
   workflow_dispatch:
 
-env:
-  PLATFORMSH_CLI_TOKEN: ${{ secrets.TEMPLATES_CLI_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-
 jobs:
-  run_dm_update:
-    name: Trigger Source Op
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'platformsh-templates' }}
-    steps:
-      - name: 'Run source ops'
-        id: run-source-op
-        uses: platformsh/gha-run-sourceops-update@main
-        with:
-          github_token: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-          platformsh_token: ${{ secrets.TEMPLATES_CLI_TOKEN }}
+  run-reusable-sop-update:
+    uses: platformsh-templates/ghrw-templates/.github/workflows/sourceops.yaml@main
+    secrets: inherit

--- a/common/sourceop-auto-update/.github/workflows/testprenvironment.yaml
+++ b/common/sourceop-auto-update/.github/workflows/testprenvironment.yaml
@@ -1,4 +1,14 @@
-name: "TestPrEnvironment"
+########################################################################################################################
+##                                                                                                                    ##
+## This github workflow file is part of the Platform.sh process of updating and maintaining our collection of         ##
+## templates. For more information see https://github.com/platformsh-templates/ghrw-templates                         ##
+## and https://github.com/search?q=topic%3Agithub-action+org%3Aplatformsh                                             ##
+##                                                                                                                    ##
+##                                       YOU CAN SAFELY DELETE THIS FILE                                              ##
+##                                                                                                                    ##
+########################################################################################################################
+name: "TestPullRequestEnv"
+run-name: "TestPullRequestEnv"
 on:
   workflow_run:
     workflows: [ "platformsh" ]
@@ -7,32 +17,16 @@ on:
   pull_request:
     branches:
       - master
-env:
-  GITHUB_TOKEN: ${{ secrets.TEMPLATES_GITHUB_TOKEN }}
-jobs:
-  test-pr-env:
-    name: TestPrEnvironment
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'platformsh-templates' }}
-    steps:
-      - name: 'Wait for psh and get target url'
-        id: get-target-url
-        uses: platformsh/gha-retrieve-psh-prenv-url@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Does Our App Work?'
-        id: test-environment
-        run: |
-          target_url=${{ steps.get-target-url.outputs.target_url }}
-          echo "::notice::The target url returned from our github action: ${target_url}"
-          #ok, so for whatever strange reason, our integration returns the http version of the PR environment, not https
-          #hence to parameter expansion replacement.
-          #we dont need the whole response (yet), just see if we get a 200
-          response=$(curl -s -o /dev/null -I -w "%{http_code}" "${target_url//http:/https:}");
-          if [[ "200" == "${response}" ]]; then
-            echo "::notice::Environment responded with http header 200"
-          else
-            echo "::error::Response from environment was something other than 200. Response returned was ${response}"
-            exit 1;
-          fi
+      - main
 
+jobs:
+  # !!!! WARNING !!!! #
+  # If for some reason you decide to change this jobid from `TestPrEnv-CW` to something else, you will also need to
+  # add a repository variable of CW_JOBID with a value of the new jobid.
+  # Explanation: the jobid below is part of the status check name that is used in preparing the repository for an
+  # auto-accepting PR. If you change the jobid below, but do not add the repo variable with this value, then the repository
+  # will be configured to require a status check that does not exist and it will be unable to accept the PR. In addition,
+  # you will be blocked from accepting the PR until you remove it from the repo's settings
+  TestPrEnv-CW:
+    uses: platformsh-templates/ghrw-templates/.github/workflows/testprenvironment.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Closes #829 
As our automatic maintenance of templates has progressed, so has the amount of logic contained in the individual github workflow files. To prevent us from having to make large scale updates to the github workflow files across all template repositories in the future, this update changes all workflows to use a collection of [reusable workflows](https://github.com/platformsh-templates/ghrw-templates) so we can make most changes there and have it affect all individual template repositories at once.