### PR TITLE
Fix git repository route protocol

### DIFF
--- a/templates/typo3-v11/.platform.template.yaml
+++ b/templates/typo3-v11/.platform.template.yaml
@@ -20,7 +20,7 @@ info:
           Composer-based build<br />
 
 initialize:
-  repository: git://github.com/platformsh-templates/typo3-v11.git@master
+  repository: https://github.com/platformsh-templates/typo3-v11.git@master
   config: null
   files: []
   profile: TYPO3


### PR DESCRIPTION
The current version of the template points to the Typo3-v11 repo using the `git` protocol. This causes an error when Platform.sh tries to clone the repository. Changing it to `https` resolves this.