### PR TITLE
[Enhancement] adds project issues sync workflow

### DIFF
--- a/common/all/.github/workflows/project-issues.yaml
+++ b/common/all/.github/workflows/project-issues.yaml
@@ -1,0 +1,20 @@
+########################################################################################################################
+##                                                                                                                    ##
+## This github workflow file is part of the Platform.sh process of updating and maintaining our collection of         ##
+## templates. For more information see https://github.com/platformsh-templates/ghrw-templates                         ##
+## and https://github.com/search?q=topic%3Agithub-action+org%3Aplatformsh                                             ##
+##                                                                                                                    ##
+##                                       YOU CAN SAFELY DELETE THIS FILE                                              ##
+##                                                                                                                    ##
+########################################################################################################################
+name: Sync repository issues to template-builder project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  run-reusable-issue-sync:
+    uses: platformsh-templates/ghrw-templates/.github/workflows/project-issues.yaml@main
+    secrets: inherit


### PR DESCRIPTION
adds project-issues sync workflow to common/all/.github/workflows to have each individual template repository's issues to the template builder project

Closes #838 

@chadwcarlson I wasn't sure if you wanted this workflow to be added to **every** template (ie `common/all/.github/workflows`) or only those templates where we've added the source-operations workflows. This PR has it placed in  `all` but I can move it if you want.