### PR TITLE
adds `info:class: demo` property to the following templates

### DIFF
--- a/templates/drupal9-multisite/.platform.template.yaml
+++ b/templates/drupal9-multisite/.platform.template.yaml
@@ -8,6 +8,7 @@ info:
     <p>It also includes instructions and a script to help with setting up additional multisite instances, although depending on your particular needs it may require some customization.</p>
     <p>Drupal is a flexible and extensible PHP-based CMS framework capable of hosting multiple sites on a single code base.</p>
 
+  class: demo
   tags:
   - PHP
   - Drupal

--- a/templates/eleventy-strapi/.platform.template.yaml
+++ b/templates/eleventy-strapi/.platform.template.yaml
@@ -8,6 +8,7 @@ info:
       <p>Note that there are several setup steps required after the first deploy. An <code>article</code> content type has already been committed, but you will still need to follow the post deploy instructions to add content and define permissions for Eleventy to consume it.</p>
       <p>Eleventy is a static site generator written in Node.js, and Strapi is a headless CMS framework also written in Node.js.</p>
 
+  class: demo
   tags:
   - Node.js
   - CMS

--- a/templates/gatsby-drupal/.platform.template.yaml
+++ b/templates/gatsby-drupal/.platform.template.yaml
@@ -28,6 +28,7 @@ info:
      <p>Note that after you have completed the Drupal installation and included a few articles, the project will require a redeploy to build and deploy Gatsby for the first time. See the included README's post-install section for details.</p>
      <p>Gatsby is a free and open source framework based on React that helps developers build statically-generated websites and apps, and Drupal is a flexible and extensible PHP-based CMS framework.</p>
   # A list of tags associated with the template.
+  class: demo
   tags:
   - Node.js
   - PHP

--- a/templates/gatsby-wordpress/.platform.template.yaml
+++ b/templates/gatsby-wordpress/.platform.template.yaml
@@ -7,6 +7,7 @@ info:
       <p>This template builds a two application project to deploy the Headless CMS pattern using Gatsby as its frontend and WordPress for its backend. The `gatsby-source-wordpress` source plugin is used to pull data from WordPress during the `post_deploy` hook into the Gatsby Data Layer and build the frontend site. Gatsby utilizes the Platform.sh Configuration Reader library for Node.js to define the backend data source in its configuration. It is intended for you to use as a starting point and modify for your own needs.</p>
       <p>Note that after you have completed the WordPress installation, the project will require a redeploy to build and deploy Gatsby for the first time. See the included README's post-install section for details.</p>
       <p>Gatsby is a free and open source framework based on React that helps developers build statically-generated websites and apps, and WordPress is a blogging and lightweight CMS written in PHP.</p>
+  class: demo
   tags:
   - Node.js
   - PHP

--- a/templates/hugo/.platform.template.yaml
+++ b/templates/hugo/.platform.template.yaml
@@ -6,6 +6,7 @@ info:
   description: |
       <p>This template provides a basic Hugo skeleton.  All files are generated at build time, so at runtime only static files need to be served.  The Hugo executable itself is downloaded during the build hook. You can specify the version to use by updating the `.platform.app.yaml` file.  It also includes a minimal template to get you started, but you are free to replace it with your own template.</p>
       <p>Hugo is a static site generator written in Go, using Go's native template packages for formatting.</p>
+  class: demo
   tags:
   - Go
   - CMS

--- a/templates/nextjs-drupal/.platform.template.yaml
+++ b/templates/nextjs-drupal/.platform.template.yaml
@@ -28,6 +28,7 @@ info:
     description: |
       <p>This template demonstrates a multi-app deployment on Platform.sh, in this case, a Next.js frontend consuming data from a Drupal 9 backend running on the same environment. It is based largely on the configuration instructions provided by the Next-Drupal project by Chapter Three.</p>
       <p>Next.js is an open-source web framework written for Javascript, and Drupal is a flexible and extensible PHP-based CMS framework.</p>
+    class: demo
     # A list of tags associated with the template.  These should be highly generic terms like "CMS", "Framework", and
     # the language in which the application is written.
     tags:

--- a/templates/nextjs-wordpress/.platform.template.yaml
+++ b/templates/nextjs-wordpress/.platform.template.yaml
@@ -28,6 +28,7 @@ info:
     description: |
       <p>This template demonstrates a multi-app deployment on Platform.sh, in this case, a Next.js frontend consuming data from a WordPress backend running on the same environment. It is based largely on the instructions provided by NextJS for a WordPress Demo site.</p>
       <p>Next.js is an open-source web framework written for Javascript, and WordPress is a flexible and extensible PHP-based CMS framework.</p>
+    class: demo
     # A list of tags associated with the template.  These should be highly generic terms like "CMS", "Framework", and
     # the language in which the application is written.
     tags:


### PR DESCRIPTION
adds `info:class: demo` property to .platform.template.yaml for the following templates:

- drupal9-multisite
- eleventy-strapi
- gatsby-drupal
- gatsby-wordpress
- hugo
- nextjs-drupal
- nextjs-wordpress
Associated with #842 