### PR TITLE
[TB clean-up] Resolve ours vs theirs .github directory

### DIFF
--- a/project/drupal.py
+++ b/project/drupal.py
@@ -162,7 +162,6 @@ class Drupal9_govcms9(RemoteProject):
     def update(self):
         return super(Drupal9_govcms9, self).update + [
             'cd {0} && rm -rf .circleci'.format(self.builddir),
-            'cd {0} && rm -rf .github'.format(self.builddir),
             'cd {0} && rm -rf .tugboat'.format(self.builddir),
             'cd {0} && composer remove php {1}'.format(self.builddir,
                                                        self.composer_defaults().replace('--prefer-dist', '')),

--- a/project/sylius.py
+++ b/project/sylius.py
@@ -18,7 +18,6 @@ class Sylius(RemoteProject):
         return super(Sylius, self).platformify + [
             'cd {0} && cp README.md README_upstream.md'.format(self.builddir),
             'cd {0} && ls -a'.format(self.builddir),
-            'cd {0} && rm -rf .github'.format(self.builddir),
             'cd {0} && [ ! -e "./config/packages/swiftmailer.yaml" ] || rm "./config/packages/swiftmailer.yaml"'.format(self.builddir),
             'cd {0} && composer config allow-plugins.symfony/flex true --no-plugins '.format(self.builddir),
             'cd {0} && composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true --no-plugins '.format(

--- a/project/wordpress.py
+++ b/project/wordpress.py
@@ -38,10 +38,10 @@ class WordPressComposerBase(RemoteProject):
 
     # until we convert all php templates to use this method, we need to remove the 'ignore platform' composer param
     def composer_defaults(self):
-        #get the default list from parent
+        # get the default list from parent
         composerDefaults = super(WordPressComposerBase, self).composer_defaults()
-        #remove the ignore platform php line
-        composerDefaults = composerDefaults.replace(' --ignore-platform-req=php','')
+        # remove the ignore platform php line
+        composerDefaults = composerDefaults.replace(' --ignore-platform-req=php', '')
 
         return composerDefaults
 
@@ -64,18 +64,21 @@ class WordPressComposerBase(RemoteProject):
 
     @property
     def platformify(self):
-        #get the versions
+        # get the versions
         actions = super(WordPressComposerBase, self).platformify
-        if hasattr(self,'type') and hasattr(self,'typeVersion') and 'php' == self.type:
+        if hasattr(self, 'type') and hasattr(self, 'typeVersion') and 'php' == self.type:
             actions = [
-                "cd {0} && composer config --no-plugins allow-plugins.johnpbloch/wordpress-core-installer true".format(self.builddir),
-                "cd {0} && composer config --no-plugins allow-plugins.composer/installers true".format(self.builddir),
-                "echo 'Adding composer config:platform:php'",
-                "cd {0} && composer config platform.php {1}".format(self.builddir,self.typeVersion)
-            ] + actions
+                          "cd {0} && composer config --no-plugins allow-plugins.johnpbloch/wordpress-core-installer true".format(
+                              self.builddir),
+                          "cd {0} && composer config --no-plugins allow-plugins.composer/installers true".format(
+                              self.builddir),
+                          "echo 'Adding composer config:platform:php'",
+                          "cd {0} && composer config platform.php {1}".format(self.builddir, self.typeVersion)
+                      ] + actions
             # now add the child commands
             actions = actions + self._platformify
-            actions = actions + ["echo 'Removing composer config:platform'", "cd {0} && composer config --unset platform".format(self.builddir)]
+            actions = actions + ["echo 'Removing composer config:platform'",
+                                 "cd {0} && composer config --unset platform".format(self.builddir)]
             # print("Our complete list of actions")
             # pprint(actions)
         else:
@@ -86,6 +89,7 @@ class WordPressComposerBase(RemoteProject):
     @property
     def _platformify(self):
         return []
+
 
 class Wordpress_bedrock(WordPressComposerBase):
     major_version = '1'
@@ -98,13 +102,13 @@ class Wordpress_bedrock(WordPressComposerBase):
             return super(Wordpress_bedrock, self).wp_modify_composer(composer, self.unPinDependencies)
 
         return [
-            'cd {0} && rm -rf .circleci && rm -rf .github'.format(self.builddir),
-        ] + super(Wordpress_bedrock, self).platformify + [
-            (self.modify_composer, [wp_modify_composer]),
-            'cd {0} && composer require platformsh/config-reader wp-cli/wp-cli-bundle psy/psysh'.format(
-                self.builddir) + self.composer_defaults(),
-            'cd {0} && composer update'.format(self.builddir),
-        ]
+                   'cd {0} && rm -rf .circleci'.format(self.builddir),
+               ] + super(Wordpress_bedrock, self).platformify + [
+                   (self.modify_composer, [wp_modify_composer]),
+                   'cd {0} && composer require platformsh/config-reader wp-cli/wp-cli-bundle psy/psysh'.format(
+                       self.builddir) + self.composer_defaults(),
+                   'cd {0} && composer update'.format(self.builddir),
+               ]
 
 
 class Wordpress_woocommerce(WordPressComposerBase):
@@ -122,13 +126,13 @@ class Wordpress_woocommerce(WordPressComposerBase):
             return super(Wordpress_woocommerce, self).wp_modify_composer(composer, self.unPinDependencies)
 
         return [
-            'cd {0} && rm -rf .circleci && rm -rf .github'.format(self.builddir),
-        ] + super(Wordpress_woocommerce, self).platformify + [
-            (self.modify_composer, [wp_modify_composer]),
-            'cd {0} && rm -rf .circleci && rm -rf .github'.format(self.builddir),
-            'cd {0} && composer require wpackagist-plugin/woocommerce wpackagist-plugin/jetpack'.format(
-                self.builddir) + self.composer_defaults(),
-        ]
+                   'cd {0} && rm -rf .circleci'.format(self.builddir),
+               ] + super(Wordpress_woocommerce, self).platformify + [
+                   (self.modify_composer, [wp_modify_composer]),
+                   'cd {0} && rm -rf .circleci'.format(self.builddir),
+                   'cd {0} && composer require wpackagist-plugin/woocommerce wpackagist-plugin/jetpack'.format(
+                       self.builddir) + self.composer_defaults(),
+               ]
 
 
 class Wordpress_composer(WordPressComposerBase):


### PR DESCRIPTION
Closes #881 
Previously, individual template classes were manually removing the `.github` directory, along with other CI-related services (e.g. `.circleci`, `.tugboat`, etc.). However, that meant _our_ `.github` directory was also being removed. 

This PR attempts to resolve this issue of theirs vs our `.github` directory:

1. after cloning our template repository, checks for the existence of a `.github` directory, and if present, renames to `tmp.github`
2. after pulling from the upstream, if a `.github` directory is reintroduced, deletes it
3. then if our `tmp.github` directory exists, renames it back to `.github`

This occurs during the `update` action, _before_ the `platformify` action which allows us to preserve the `all/common/.github` and `all/sourceop-auto-update/.github` contents as the source of truth while also preserving additional workflow files from individual template repositories (e.g. `.github/tests/vrt/*` files)

This PR also removes the deletion of the `.github` directory from the following template classes:
* Drupal9_Govcms9
* Sylius
* WordPress Bedrock
* WordPress WooCommerce