### PR TITLE
corrects indentation in yaml properties

### DIFF
--- a/templates/strapi4/platformsh.wizard.yaml
+++ b/templates/strapi4/platformsh.wizard.yaml
@@ -2,17 +2,16 @@ steps:
     - id: "download_cli"
       label: "Download the CLI"
       title: "Download the Platform.sh CLI"
-      subtitle: "Download the Platform.sh CLI"
       required: true
       bodyText: "<p>To install the CLI, use the command for either macOS and Windows as shown.</p>\n<p>For more info about our CLI check out our <a href='https://docs.platform.sh/development/cli.html#cli-command-line-interface'>documentation</a> or take a look at our <a href='https://github.com/platformsh/cli'>CLI source code</a>.</p>"
-    copyCode:
-      - label: "macOS and Linux Installer (using Homebrew)"
-        code:
-          - "brew install platformsh/tap/platformsh-cli"
-      - label: "Windows Installer (using Scoop)"
-        code:
-          - "scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git"
-          - "scoop install platform"
+      copyCode:
+        - label: "macOS and Linux Installer (using Homebrew)"
+          code:
+            - "brew install platformsh/tap/platformsh-cli"
+        - label: "Windows Installer (using Scoop)"
+          code:
+            - "scoop bucket add platformsh https://github.com/platformsh/homebrew-tap.git"
+            - "scoop install platform"
     - id: "download_project"
       label: "Download your project"
       title: "Download your project to start using it"


### PR DESCRIPTION
incorrect indentation in strapi4's wizard file was causing it to display incorrectly in platform.sh console. 